### PR TITLE
Fix Snappy/S2 block fallback max size

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -58,7 +58,7 @@ func Decode(dst, src []byte) ([]byte, error) {
 	}
 
 	if !isMLZ {
-		if l, _ := s2.DecodedLen(block); l > MaxBlockSize {
+		if l, _ := s2.DecodedLen(block); l > s2.MaxBlockSize {
 			return nil, ErrTooLarge
 		}
 		if dst, err := s2.Decode(dst, block); err != nil {


### PR DESCRIPTION
Allow bigger S2/Snappy blocks.

Fixes #14