### PR TITLE
Add Search Table Checksum

### DIFF
--- a/SPEC_SEARCH.md
+++ b/SPEC_SEARCH.md
@@ -49,6 +49,7 @@ The Block Search Table is an optional chunk that will come before a block that r
 | 1          | Base Table Size in log2       |
 | 0/8/32/1+n | Prefix values                 |
 | 1          | Reductions from Base Table    |
+| 4          | CRC32 of table entries        |
 | n          | Table entries. n = 2^(BT-R-3) |
 
 Search pattern length, base table size and prefix values *should* match the values given in chunk type 0x44.
@@ -58,6 +59,9 @@ If no chunk type 0x44 has been seen or the values are different, the decoder *ma
 
 The table entries are bits, where the search pattern resolves to 'x' 
 can be resolved by looking up `table[x>>3] & (1<<(x&7))`.
+
+A CRC32 is calculated of the table entries, similar to the CRC32 of the block data. 
+See section [3. Checksum format](SPEC.md#3-checksum-format).
 
 Note that encoders can decide to omit the Search Table for any block if it is deemed not worth the space, 
 for example, if there are too many collisions for the table to provide any benefit.

--- a/search_examples_test.go
+++ b/search_examples_test.go
@@ -144,7 +144,7 @@ func ExampleSearchStats_Fprint() {
 	// Blocks searched: 1 (50.0%), false positive: 0 (0.0%)
 	// Bytes skipped: <N> compressed, searched: 8192 uncompressed
 	// Tables: 2 present, 0 missing, 0 unusable
-	// Table bits/byte: 0.0391, log2: 8.0, avg reductions: 5.0
-	// Table total: 80 bytes, avg 40 bytes/table, 0.49% of 16384 uncompressed
+	// Table bits/byte: 0.0430, log2: 8.0, avg reductions: 5.0
+	// Table total: 88 bytes, avg 44 bytes/table, 0.54% of 16384 uncompressed
 	// Table population: avg 2.7%, min 1.6%, max 3.9%
 }

--- a/search_reader.go
+++ b/search_reader.go
@@ -350,7 +350,7 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 			if !s.readFull(s.buf[:chunkLen]) {
 				return s.err
 			}
-			cfg, reductions, table, err := parseSearchTable(s.buf[:chunkLen])
+			cfg, reductions, table, err := parseSearchTable(s.buf[:chunkLen], s.ignoreCRC)
 			if err != nil {
 				return err
 			}

--- a/search_table.go
+++ b/search_table.go
@@ -126,11 +126,16 @@ func (c *SearchTableConfig) validate() error {
 	return nil
 }
 
+// searchTablePayloadSize returns the 0x45 payload size for the given table length.
+func (c *SearchTableConfig) searchTablePayloadSize(tableLen int) int {
+	// 3 (type+matchLen+baseSize) + prefixSize + 1 (reductions) + 4 (crc) + table
+	return 3 + c.prefixSize() + 1 + 4 + tableLen
+}
+
 // maxChunkSize returns the maximum 0x45 chunk size (header + payload) for this config.
+// Max table = 2^(baseTableSize-3) bytes (0 reductions).
 func (c *SearchTableConfig) maxChunkSize() int {
-	// 4 (chunk header) + 3 (type+matchLen+baseSize) + prefixSize + 1 (reductions) + max table bytes
-	// Max table = 2^(baseTableSize-3) bytes (0 reductions).
-	return 4 + 3 + c.prefixSize() + 1 + (1 << (c.baseTableSize - 3))
+	return 4 + c.searchTablePayloadSize(1<<(c.baseTableSize-3))
 }
 
 func (c *SearchTableConfig) prefixSize() int {
@@ -219,17 +224,19 @@ func (c *SearchTableConfig) marshalSearchInfoChunk() []byte {
 	return c.appendConfig(dst)
 }
 
-// marshalSearchTableChunk produces a complete 0x45 chunk.
-func marshalSearchTableChunk(cfg *SearchTableConfig, reductions uint8, table []byte) []byte {
-	return appendSearchTableChunk(nil, cfg, reductions, table)
-}
-
 // appendSearchTableChunk appends a complete 0x45 chunk to dst.
 func appendSearchTableChunk(dst []byte, cfg *SearchTableConfig, reductions uint8, table []byte) []byte {
-	dst = appendChunkHeader(dst, chunkTypeSearchTable, 3+cfg.prefixSize()+1+len(table))
+	dst = appendSearchTableHeader(dst, cfg, reductions, table)
+	return append(dst, table...)
+}
+
+// appendSearchTableHeader appends everything in the 0x45 chunk before the table bytes:
+// chunk header, config, reductions, and CRC of table.
+func appendSearchTableHeader(dst []byte, cfg *SearchTableConfig, reductions uint8, table []byte) []byte {
+	dst = appendChunkHeader(dst, chunkTypeSearchTable, cfg.searchTablePayloadSize(len(table)))
 	dst = cfg.appendConfig(dst)
 	dst = append(dst, reductions)
-	return append(dst, table...)
+	return binary.LittleEndian.AppendUint32(dst, crc(table))
 }
 
 // parseSearchInfo parses the payload (after chunk header) of a 0x44 chunk.
@@ -273,7 +280,7 @@ func parseSearchInfo(payload []byte) (SearchTableConfig, error) {
 }
 
 // parseSearchTable parses the payload (after chunk header) of a 0x45 chunk.
-func parseSearchTable(payload []byte) (cfg SearchTableConfig, reductions uint8, table []byte, err error) {
+func parseSearchTable(payload []byte, ignoreCRC bool) (cfg SearchTableConfig, reductions uint8, table []byte, err error) {
 	cfg, err = parseSearchInfo(payload)
 	if err != nil {
 		return
@@ -286,11 +293,17 @@ func parseSearchTable(payload []byte) (cfg SearchTableConfig, reductions uint8, 
 	reductions = payload[off]
 	table = payload[off+1:]
 	expectedSize := 1 << (cfg.baseTableSize - reductions - 3)
-	if len(table) < expectedSize {
-		err = fmt.Errorf("minlz: search table data too short: got %d, want %d", len(table), expectedSize)
+	if len(table) < expectedSize+4 {
+		err = fmt.Errorf("minlz: search table data too short: got %d, want %d", len(table), expectedSize+4)
 		return
 	}
+	// Read stored CRC
+	crc32 := binary.LittleEndian.Uint32(table)
+	table = table[4:]
 	table = table[:expectedSize]
+	if !ignoreCRC && crc32 != crc(table) {
+		err = fmt.Errorf("minlz: search table CRC mismatch")
+	}
 	return
 }
 

--- a/search_test.go
+++ b/search_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"strings"
 	"testing"
 )
 
@@ -272,11 +273,11 @@ func TestChunkRoundtrip(t *testing.T) {
 		table[0] = 0xff
 		table[31] = 0x01
 		reductions := cfg.baseTableSize - 8
-		chunk := marshalSearchTableChunk(&cfg, reductions, table)
+		chunk := appendSearchTableChunk(nil, &cfg, reductions, table)
 		if chunk[0] != chunkTypeSearchTable {
 			t.Fatalf("expected chunk type 0x45, got 0x%x", chunk[0])
 		}
-		pcfg, pred, ptable, err := parseSearchTable(chunk[4:])
+		pcfg, pred, ptable, err := parseSearchTable(chunk[4:], false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -286,6 +287,51 @@ func TestChunkRoundtrip(t *testing.T) {
 		if !bytes.Equal(ptable, table) {
 			t.Fatal("table data mismatch")
 		}
+	}
+}
+
+func TestSearchTableCRCMismatch(t *testing.T) {
+	cfg := withBaseTableSize(NewSearchTableConfig().WithMatchLen(4), 12)
+	if err := cfg.validate(); err != nil {
+		t.Fatal(err)
+	}
+	table := make([]byte, 32)
+	table[0] = 0xff
+	table[31] = 0x01
+	reductions := cfg.baseTableSize - 8
+	chunk := appendSearchTableChunk(nil, &cfg, reductions, table)
+
+	if _, _, _, err := parseSearchTable(chunk[4:], false); err != nil {
+		t.Fatalf("clean chunk should parse, got %v", err)
+	}
+
+	// Corrupt a table byte; CRC must catch it.
+	corruptTable := make([]byte, len(chunk))
+	copy(corruptTable, chunk)
+	corruptTable[len(corruptTable)-1] ^= 0x01
+	_, _, _, err := parseSearchTable(corruptTable[4:], false)
+	if err == nil {
+		t.Fatal("expected CRC mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "CRC mismatch") {
+		t.Fatalf("expected CRC mismatch error, got: %v", err)
+	}
+	_, _, _, err = parseSearchTable(corruptTable[4:], true)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Corrupt the stored CRC; same outcome.
+	corruptCRC := make([]byte, len(chunk))
+	copy(corruptCRC, chunk)
+	crcOff := 4 + 3 + cfg.prefixSize() + 1
+	corruptCRC[crcOff] ^= 0x01
+	_, _, _, err = parseSearchTable(corruptCRC[4:], false)
+	if err == nil {
+		t.Fatal("expected CRC mismatch error after CRC corruption, got nil")
+	}
+	if !strings.Contains(err.Error(), "CRC mismatch") {
+		t.Fatalf("expected CRC mismatch error, got: %v", err)
 	}
 }
 
@@ -1138,7 +1184,7 @@ func TestBlockTableIndexCorrectness(t *testing.T) {
 				case chunkTypeSearchInfo:
 					pos += chunkLen
 				case chunkTypeSearchTable:
-					cfg, red, tbl, err := parseSearchTable(stream[pos : pos+chunkLen])
+					cfg, red, tbl, err := parseSearchTable(stream[pos:pos+chunkLen], false)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/writer.go
+++ b/writer.go
@@ -93,6 +93,7 @@ type Writer struct {
 
 	searchCfg      *SearchTableConfig
 	searchInfoBuf  []byte // cached 0x44 chunk
+	searchHdrBuf   []byte // scratch 0x45 header (sync path)
 	searchMaxChunk int    // max 0x45 chunk size, 0 if no search
 
 	// wroteStreamHeader is whether we have written the stream header.
@@ -1171,12 +1172,20 @@ func (w *Writer) writeSearchTableSync(uncompressed, overlap []byte) error {
 	if table == nil {
 		return nil
 	}
-	chunk := marshalSearchTableChunk(w.searchCfg, reductions, table)
-	n, err := w.writer.Write(chunk)
+	w.searchHdrBuf = appendSearchTableHeader(w.searchHdrBuf[:0], w.searchCfg, reductions, table)
+	n, err := w.writer.Write(w.searchHdrBuf)
 	if err != nil {
 		return w.err(err)
 	}
-	if n != len(chunk) {
+	if n != len(w.searchHdrBuf) {
+		return w.err(io.ErrShortWrite)
+	}
+	w.written += int64(n)
+	n, err = w.writer.Write(table)
+	if err != nil {
+		return w.err(err)
+	}
+	if n != len(table) {
 		return w.err(io.ErrShortWrite)
 	}
 	w.written += int64(n)


### PR DESCRIPTION
Adds a CRC32 (snappy variant, used elsewhere) for table entries.

Reader is allowed to skip via `BlockSearchIgnoreCRC()`.

Modifies only unreleased types.