### PR TITLE
Add sparse & compressed search index blocks

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -120,7 +120,7 @@ jobs:
     strategy:
       matrix:
         tags: [ '', 'nounsafe', '"noasm,nounsafe"' ]
-        tests: ['FuzzEncodingBlocks', 'FuzzDecode', 'FuzzStreamEncode', 'FuzzStreamDecode', 'FuzzLZ4Block']
+        tests: ['FuzzEncodingBlocks', 'FuzzDecode', 'FuzzStreamEncode', 'FuzzStreamDecode', 'FuzzLZ4Block', 'FuzzCompressedSearchRoundtrip', 'FuzzDecodeCompressedSearchChunk']
         os: [ubuntu-latest, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -120,7 +120,7 @@ jobs:
     strategy:
       matrix:
         tags: [ '', 'nounsafe', '"noasm,nounsafe"' ]
-        tests: ['FuzzEncodingBlocks', 'FuzzDecode', 'FuzzStreamEncode', 'FuzzStreamDecode', 'FuzzLZ4Block', 'FuzzCompressedSearchRoundtrip', 'FuzzDecodeCompressedSearchChunk']
+        tests: ['FuzzEncodingBlocks', 'FuzzDecodeBlock', 'FuzzStreamEncode', 'FuzzStreamDecode', 'FuzzLZ4Block', 'FuzzCompressedSearchRoundtrip', 'FuzzDecodeCompressedSearchChunk']
         os: [ubuntu-latest, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     steps:

--- a/SEARCH.md
+++ b/SEARCH.md
@@ -85,6 +85,48 @@ single digits because 4-byte digit sequences are ubiquitous.
 cfg := minlz.NewSearchTableConfig().WithMatchLen(5)
 ```
 
+### Table Reduction Limit
+
+Once a base table is built, it can be reduced — folded in half by OR-ing the
+upper half into the lower half. Each reduction halves the size of the table
+on the wire and doubles the population density (because two slots' worth of
+1-bits are merged into one). Reductions keep going until the projected
+population exceeds this limit; whatever is left is what the stream
+carries.
+
+The trade-off is direct:
+
+- **Smaller table** = fewer bytes per block stored alongside the data, but
+  more **false positives** at search time (two distinct hash values can now
+  share a slot, so a "maybe" answer is more often wrong → more blocks
+  decoded unnecessarily).
+- **Larger table** = more bytes on the wire, but **fewer collisions** —
+  blocks that don't contain the pattern are skipped more often.
+
+A useful intuition: every reduction roughly doubles the collision rate.
+A 25 % populated reduced table will spuriously match ~25 % of the time
+*per window check*. With a long pattern this multiplies down (each window
+check is independent), so even a moderately populated table filters
+aggressively for patterns longer than `matchLen`. Short patterns (close to
+`matchLen` bytes) get all their filtering from a single window and benefit
+most from a sparser table.
+
+Defaults:
+
+- Library default: 25 %.
+- `mz` CLI default: 50 %, automatically tightened (halved with prefix or
+  compression, divided by 3 with both) since [prefixed tables](#prefixes)
+  and [compressed tables](#compressed-search-tables-opt-in) both want
+  sparser bitmaps.
+
+```go
+cfg := minlz.NewSearchTableConfig().WithMaxReducedPopulation(30)
+```
+
+When compression is on, lower limits (<20 %) has much less of an impact on
+stream size than the default because the extra bytes spent on a larger bitmap
+are recovered by the huff0 / sparse encoding.
+
 ### Table Max Population Size
 
 Maximum percentage of bits that may be set in the base table before it is discarded
@@ -102,21 +144,57 @@ with higher false-positive rates.
 cfg := minlz.NewSearchTableConfig().WithMaxPopulation(50)
 ```
 
-### Table Reduction Limit
+### Compressed Search Tables (opt-in)
 
-Maximum population percentage of the *reduced* table. Library default: 25%.
-The `mz` CLI defaults to 50% without prefix and 25% with prefix.
+Search-table bitmaps can optionally be stored compressed. This is a stream-
+level opt-in: the encoder shrinks each per-block bitmap when doing so saves
+bytes, and the decoder unpacks it on the fly during search.
 
-After the base table is built, it is iteratively halved by folding (OR-ing) the upper
-half into the lower half. Each reduction halves the table size but increases the
-population density. Reductions stop before this threshold is exceeded.
+When it helps most:
 
-Lower values produce smaller tables (fewer bytes per block in the compressed stream) but
-with more false positives. Higher values keep larger, sparser tables that skip more blocks.
+- **High-Quality tables**. This will reduce the impact of having a low
+  reduction limit and therefore less collisions.
+- **Sparse search tables** (small prefix matchLen, structured data with a
+  selective prefix). Often shrinks the table by 5×–50× on the wire.
+- **Very dense tables** where the same byte value repeats (especially
+  all-zero or all-one bitmaps that compress to a few bytes regardless of
+  size).
+
+When it makes little difference:
+
+- Tables with ~50% population: byte entropy is already maximal, so there's
+  nothing to compress. The encoder detects this and skips the compressed
+  form by default.
+
+Enable it via `WithCompression` on the search table config:
 
 ```go
-cfg := minlz.NewSearchTableConfig().WithMaxReducedPopulation(30)
+// Defaults: 10 % popcount band, no stats hook.
+cfg := minlz.NewSearchTableConfig().WithCompression()
+w := minlz.NewWriter(out, minlz.WriterSearchTable(cfg))
 ```
+
+Tuning options (all optional):
+
+| Option                                   | Description                                                                                       |
+|------------------------------------------|---------------------------------------------------------------------------------------------------|
+| `CompressedSearchSkipPct(pct float64)`   | Skip compression when popcount % is within ±pct of 50 (default 10 %).                             |
+| `CompressedSearchStatsHook(fn)`          | Per-bitmap callback with disposition counts and on-wire sizes — useful for tuning.                |
+| `CompressedSearchForce()`                | Emit the compressed chunk even when larger than the uncompressed form. Benchmarking only.         |
+
+When compression is enabled, the recommended `MaxReducedPopulation` is
+lower than the default — leaving tables sparser pays off because the bytes
+shrink so much. The `mz` CLI does this automatically; for library use,
+call `.WithMaxReducedPopulation(15)` (or pass `-search.lim` to `mz`).
+
+Decoding is transparent: a `BlockSearcher` over a stream that mixes
+compressed and uncompressed search tables handles both with no caller
+opt-in. The per-bitmap unpack runs in parallel for large bitmaps, so
+search throughput is unchanged in practice.
+
+For format details see `SPEC_SEARCH.md` §2.2 / §2.2.1.
+
+Some decoders may not support compressed search tables.
 
 ### Prefixes
 
@@ -177,7 +255,14 @@ mz c -search -search.prefixes='":'  file.log       # byte prefixes " and :
 mz c -search -search.prefix='id:"' file.log        # long prefix
 mz c -search -search.max=50 -search.lim=30 file.log # custom population limits
 mz c -bs=1MB -search file.log                       # 1MB blocks (more granular skipping)
+mz c -search -search.compress file.log              # also compress the search tables
+mz c -search -search.compress -search.compress.skip=5 file.log # tighter popcount band
 ```
+
+When `-search.compress` is set, `-search.lim` is automatically tightened
+(divided by 2 with a prefix or compression, by 3 with both) so the encoder
+keeps larger, sparser bitmaps that compress better. Override `-search.lim`
+to taste — lower values produce sparser, more compressible tables.
 
 **Searching compressed files:**
 ```
@@ -273,15 +358,25 @@ Return values from the callback:
 
 Searcher options:
 
-| Option                       | Description                                                           |
-|------------------------------|-----------------------------------------------------------------------|
-| `BlockSearchBailOnMissing()` | Return `ErrSearchTablesUnusable` if tables are absent or incompatible |
-| `BlockSearchIgnoreCRC()`     | Skip CRC validation during search                                     |
-| `BlockSearchMaxBlockSize(n)` | Limit maximum decoded block size                                      |
+| Option                              | Description                                                                                                  |
+|-------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| `BlockSearchBailOnMissing()`        | Return `ErrSearchTablesUnusable` if tables are absent or incompatible                                        |
+| `BlockSearchIgnoreCRC()`            | Skip CRC validation during search                                                                            |
+| `BlockSearchMaxBlockSize(n)`        | Limit maximum decoded block size                                                                             |
+| `BlockSearchCollectStats()`         | Populate `SearchStats` during the search                                                                     |
+| `BlockSearchInfoCallback(fn)`       | Invoke `fn(SearchTableConfig)` when the stream's Search Info chunk is parsed — useful for logging/inspection |
 
 After `Search` returns, call `Stats()` for a `SearchStats` struct with block counts,
-skip rates, table population metrics, and byte-level statistics. Use
-`stats.Fprint(os.Stderr)` for a human-readable summary.
+skip rates, table population metrics, and byte-level statistics. When the
+stream uses compressed search tables, the stats also report:
+
+- counts of 0x45 (uncompressed) vs 0x46 (compressed) search-table chunks,
+- a per-disposition breakdown of huff0 sub-blocks (raw / RLE / sparse / tabled),
+- on-wire payload bytes for each disposition.
+
+Use `stats.Fprint(os.Stderr)` for a human-readable summary. The `mz search -v`
+command also prints the parsed Search Info config the first time it's seen
+in the stream.
 
 Note that the maximum backreference on matches is limited by the block size. 
-So a match right after a block boundary will only have the previous block's data available. 
+So a match right after a block boundary will only have the previous block's data available.

--- a/SPEC_SEARCH.md
+++ b/SPEC_SEARCH.md
@@ -11,6 +11,16 @@ checking if a pattern is present in the block.
 This can be used to determine if a block may, or definitely does *not* contain a specific pattern.
 With this information, blocks can be skipped if searching for specific patterns.
 
+### 1.1 Search Index only Streams
+
+A stream can contain search indexes only. This means that blocks are referenced into another stream.
+
+The stream should be valid, but instead of the block data, Remote Block Reference (chunk type 0x47) 
+is inserted for each data block. 
+
+This will allow the index to be stored separately from the data. 
+Alternatively, for indexing an existing stream.
+
 ## 2 New Chunks
 
 ### 2.0 Search Table Information (chunk type 0x44, skippable)
@@ -71,6 +81,79 @@ It is purely up to the decoder to decide which table(s) to use.
 
 If creating an index - as per spec [section 4.12](SPEC.md#412-index-chunk-type-0x40--optional),
 it is recommended to include this chunk as the indexed offset.
+
+### 2.2 Compressed Block Search Table (chunk type 0x46, skippable)
+
+The Compressed Block Search Table is an optional chunk that will come before a block that represents the contents.
+
+| Length     | Code  | Description                    |
+|------------|-------|--------------------------------|
+| 1          |       | Table Type                     |
+| 1          |       | Search pattern length          |
+| 1          |       | Base Table Size in log2        |
+| 0/8/32/1+n |       | Prefix values                  |
+| 1          |       | Reductions from Base Table     |
+| 4          |       | CRC32 of table entries         |
+| 1          | h0_bs | log2 huff0 block size          |
+| 1          | h0_tc | huff0 table count              |
+| ...        |       | huff0 tables                   |
+| 1          | h0_ti | huff0 table index              |
+| 1-3        | bd    | compressed length (uvarint)    |
+| bd         |       | huff0 4X compressed block data |
+| ...        |       | Additional huff0 blocks        |
+
+See Section 2.1 on how to decode table information until the huff0 section.
+
+The index bits are split into huff0 blocks.
+
+The first value (h0_bs) is the log2 of the uncompressed huff0 block size in bytes.
+The bitmap size (n) must be divisible by the huff0 block size.
+The maximum huff0 block size is 128KiB (h0_bs = 17).
+The minimum size is 32 bytes (h0_bs = 5).
+
+Tables for huff0 blocks are stored separately. There can be up to 16 tables per block.
+The encoder is allowed to reuse tables for different huff0 blocks.
+
+The encoded huff0 tables follow. This is similar to zstd, [rfc 8878](https://datatracker.ietf.org/doc/html/rfc8878#section-4.2).
+Table sizes are self-contained, but h0_tc must be read.
+
+The number of blocks can be calculated as `n / (1 << h0_bs)`.
+
+For each block the table index is specified by the h0_ti value and decoded as follows:
+
+| h0_ti value | Meaning                                   |
+|-------------|-------------------------------------------|
+| 0 -> 15     | huff0 table index                         |
+| 16          | Uncompressed block                        |
+| 17          | RLE - Read 1 byte, repeat value for block |
+| 18 -> 255   | Reserved [invalid]                        |  
+
+If h0_ti is <= 15, the compressed size follows as a uvarint - and the compressed data itself.
+Note the compressed streams are always [4 streams interleaved](https://datatracker.ietf.org/doc/html/rfc8878#name-jump_table),
+also named 4X in zstd.
+
+An uncompressed block (h0_ti = 16) and RLE (h0_ti = 17) will not have any size,
+since that can be inferred.
+
+RLE in this context means "single value repeated for the entire block" and can only be used for that.
+
+### 2.3 Remote Block Reference (chunk type 0x47, skippable)
+
+When generating search indexes from an existing stream or you, for
+another reason, want to separate the search index from the data,
+you can use the Remote Block Reference chunk type to indicate a remote block.
+
+| Length  | Description                         |
+|---------|-------------------------------------|
+| UVarInt | Block Offset                        |
+| ...     | [Additional relative block offsets] |
+
+This block replaces a block that and indicates the offset of the block in the stream.
+
+If more values are present, it indicates additional blocks without indexes between.
+These are stored as relative offsets from the current block.
+
+The block offsets must be in strictly ascending order.
 
 ## 3 Table Definition
 

--- a/SPEC_SEARCH.md
+++ b/SPEC_SEARCH.md
@@ -130,7 +130,8 @@ For each block the table index is specified by the h0_ti value and decoded as fo
 | 0 -> 15     | huff0 table index                         |
 | 16          | Uncompressed block                        |
 | 17          | RLE - Read 1 byte, repeat value for block |
-| 18 -> 255   | Reserved [invalid]                        |  
+| 18          | Sparse Bit Table                          |
+| 19 -> 255   | Reserved [invalid]                        |  
 
 If h0_ti is <= 15, the compressed size follows as a uvarint - and the compressed data itself.
 Note the compressed streams are always [4 streams interleaved](https://datatracker.ietf.org/doc/html/rfc8878#name-jump_table),
@@ -140,6 +141,22 @@ An uncompressed block (h0_ti = 16) and RLE (h0_ti = 17) will not have any size,
 since that can be inferred.
 
 RLE in this context means "single value repeated for the entire block" and can only be used for that.
+
+#### 2.2.1 Sparse Bit Table
+
+A sparse bit table can be used for very sparsely populated blocks.
+
+Like huff0 block, this starts with a uvarint encoded length in bytes.
+
+The block contains byte-encoded distances between bits.
+
+To decode, read single bytes. Each byte is the distance to the next set bit.
+Bits are counted from the least significant bit.
+
+If the byte is 255, add 255 to the distance and read the following byte.
+
+When the final byte has been read, there are no more bits. 
+The distance is not expected to reach the end of the block. 
 
 ### 2.3 Remote Block Reference (chunk type 0x47, skippable)
 

--- a/cmd/mz/compress.go
+++ b/cmd/mz/compress.go
@@ -53,7 +53,9 @@ func mainCompress(args []string) {
 		searchPfx       = fs.String("search.prefixes", "", "Search table prefix bytes (e.g. '=', '=:')")
 		searchPfxString = fs.String("search.prefix", "", "Single value longer prefix, eg 'id:\\\"'")
 		searchMax       = fs.Int("search.max", 75, "Discards search table entries with a population percentage higher than this")
-		searchLim       = fs.Int("search.lim", 50, "Stops reducing search tables if population exceeds this percentage. Divided by 2 if using prefix")
+		searchLim       = fs.Int("search.lim", 50, "Stops reducing search tables if population exceeds this percentage. Divided by 2 with prefix, 3 with compression, 5 with both")
+		searchComp      = fs.Bool("search.compress", false, "Compress search tables with huff0 (chunk type 0x46)")
+		searchCompSkip  = fs.Float64("search.compress.skip", 10.0, "Skip search table compression when |popcount - 50%| < this percentage")
 
 		// Shared
 		block  = fs.Bool("block", false, "Use as a single block. Will load content into memory. Max 8MB.")
@@ -138,10 +140,16 @@ Options:`)
 			cfg = cfg.WithBytePrefix([]byte(*searchPfx)...)
 			hasPrefix = true
 		}
-		if hasPrefix {
-			cfg = cfg.WithMaxReducedPopulation(*searchLim / 2)
-		} else {
-			cfg = cfg.WithMaxReducedPopulation(*searchLim)
+		div := 1
+		switch {
+		case *searchComp && hasPrefix:
+			div = 3
+		case hasPrefix || *searchComp:
+			div = 2
+		}
+		cfg = cfg.WithMaxReducedPopulation(*searchLim / div)
+		if *searchComp {
+			cfg = cfg.WithCompression(minlz.CompressedSearchSkipPct(*searchCompSkip))
 		}
 		opts = append(opts, minlz.WriterSearchTable(cfg))
 	}

--- a/cmd/mz/compress.go
+++ b/cmd/mz/compress.go
@@ -53,7 +53,7 @@ func mainCompress(args []string) {
 		searchPfx       = fs.String("search.prefixes", "", "Search table prefix bytes (e.g. '=', '=:')")
 		searchPfxString = fs.String("search.prefix", "", "Single value longer prefix, eg 'id:\\\"'")
 		searchMax       = fs.Int("search.max", 75, "Discards search table entries with a population percentage higher than this")
-		searchLim       = fs.Int("search.lim", 50, "Stops reducing search tables if population exceeds this percentage. Divided by 2 with prefix, 3 with compression, 5 with both")
+		searchLim       = fs.Int("search.lim", 50, "Stops reducing search tables if population exceeds this percentage. Divided by 2 when prefix or compression is enabled, by 3 when both are enabled")
 		searchComp      = fs.Bool("search.compress", false, "Compress search tables with huff0 (chunk type 0x46)")
 		searchCompSkip  = fs.Float64("search.compress.skip", 10.0, "Skip search table compression when |popcount - 50%| < this percentage")
 

--- a/cmd/mz/search.go
+++ b/cmd/mz/search.go
@@ -122,6 +122,9 @@ func searchFile(file string, pattern []byte, opts searchOpts) (found bool, stats
 	}
 	if opts.verbose {
 		bsOpts = append(bsOpts, minlz.BlockSearchCollectStats())
+		bsOpts = append(bsOpts, minlz.BlockSearchInfoCallback(func(cfg minlz.SearchTableConfig) {
+			fmt.Fprintf(os.Stderr, "%s: search info: %s\n", file, cfg)
+		}))
 	}
 	searcher := minlz.NewBlockSearcher(r, bsOpts...)
 

--- a/encode_l3.go
+++ b/encode_l3.go
@@ -272,7 +272,7 @@ func encodeBlockBest(dst, src []byte, dict *dict) (d int) {
 				}
 				m.score = score(m)
 				if debug && m.length > 0 && m.length < 3 {
-					fmt.Println("repeat", m.length, "offset", m.offset, "s", m.s, "score", m.score, "first", first, "mask", mask, "src", src[m.offset:m.offset+m.length], "src", src[m.s:m.s+m.length])
+					fmt.Println("repeat", m.length, "offset", m.offset, "s", m.s, "score", m.score, "first", first, "mask", mask, "src", string(src[m.offset:m.offset+m.length]), "src", string(src[m.s:m.s+m.length]))
 				}
 				return m
 			}

--- a/encode_test.go
+++ b/encode_test.go
@@ -150,8 +150,7 @@ func TestEmitters(t *testing.T) {
 			}
 			for ml := 4; ml <= 1<<24; ml = int(float64(ml)*lFactor + 1) {
 				//t.Run(fmt.Sprintf("len%d-o%d-lits%d", l, off, len(lits)), func(t *testing.T) {
-				var n int
-				n = emitCopy(tmp[:], off, ml)
+				var n int = emitCopy(tmp[:], off, ml)
 				in := tmp[:n]
 				s := 0
 
@@ -203,8 +202,7 @@ func TestEmitters(t *testing.T) {
 				}
 				for l := 4; l <= 11; l++ {
 					//t.Run(fmt.Sprintf("len%d-o%d-lits%d", l, off, len(lits)), func(t *testing.T) {
-					var n int
-					n = emitCopyLits2(tmp[:], lits, off, l)
+					var n int = emitCopyLits2(tmp[:], lits, off, l)
 					in := tmp[:n]
 
 					gotTag, wantTag := in[0]&3, byte(tagCopy2Fused)

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -117,7 +117,7 @@ func FuzzEncodingBlocks(f *testing.F) {
 	})
 }
 
-func FuzzDecode(f *testing.F) {
+func FuzzDecodeBlock(f *testing.F) {
 	enc := NewWriter(nil, WriterBlockSize(8<<10))
 	addCompressed := func(b []byte) {
 		if b2, err := Encode(nil, b, LevelBalanced); err == nil {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/minio/minlz
 
 go 1.24
 
-require github.com/klauspost/compress v1.18.5
+require github.com/klauspost/compress v1.18.7-0.20260521161933-6382a308581a

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/minio/minlz
 
 go 1.24
 
-require github.com/klauspost/compress v1.18.7-0.20260521161933-6382a308581a
+require github.com/klauspost/compress v1.18.7-0.20260525072120-ed100faca810

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/klauspost/compress v1.18.7-0.20260521161933-6382a308581a h1:ryjQmd2egjb2pNzxcEaSNfEuO9ML9Bz5tMiYNyU/rwk=
-github.com/klauspost/compress v1.18.7-0.20260521161933-6382a308581a/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.18.7-0.20260525072120-ed100faca810 h1:YGX2c6v8whIUjI2Djre1ldzuTyyJVF1+FRVSLl4FrTQ=
+github.com/klauspost/compress v1.18.7-0.20260525072120-ed100faca810/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
-github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
-github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
-github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.18.7-0.20260521161933-6382a308581a h1:ryjQmd2egjb2pNzxcEaSNfEuO9ML9Bz5tMiYNyU/rwk=
+github.com/klauspost/compress v1.18.7-0.20260521161933-6382a308581a/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=

--- a/index.go
+++ b/index.go
@@ -566,7 +566,7 @@ func (i *Index) JSON() []byte {
 		EstBlockUncomp:    i.estBlockUncomp,
 	}
 	for _, v := range i.Offsets {
-		x.Offsets = append(x.Offsets, offset{CompressedOffset: v.CompressedOffset, UncompressedOffset: v.UncompressedOffset})
+		x.Offsets = append(x.Offsets, offset(v))
 	}
 	b, _ := json.MarshalIndent(x, "", "  ")
 	return b

--- a/minlz.go
+++ b/minlz.go
@@ -125,6 +125,7 @@ const (
 	chunkTypeIndex                      = 0x40 // chunk id of MinLZ index
 	chunkTypeSearchInfo                 = 0x44 // search table info (per-stream)
 	chunkTypeSearchTable                = 0x45 // block search table (per-block)
+	chunkTypeSearchTableCompressed      = 0x46 // compressed block search table (per-block)
 	legacyIndexChunk                    = 0x99 // S2 index chunk id (now in user-skippable range)
 )
 

--- a/search_compressed.go
+++ b/search_compressed.go
@@ -11,11 +11,15 @@ import (
 )
 
 const (
-	cstDispRaw                 = 16
-	cstDispRLE                 = 17
-	cstMaxHuff0Tables          = 16
-	cstDefaultSkipPctTimes100  = 1000 // 5.00%
-	cstMinBitmapForCompression = 64   // huff0.Compress4X requires >= 12 bytes; below this the table overhead dwarfs savings
+	cstDispRaw                = 16
+	cstDispRLE                = 17
+	cstDispSparse             = 18
+	cstMaxHuff0Tables         = 16
+	cstDefaultSkipPctTimes100 = 1000 // 5.00%
+	// Absolute minimum bitmap that 0x46 can wrap (= smallest search table = 32 B).
+	// huff0 may fail to compress at this size, but the RLE / sparse / raw
+	// fallbacks still win against 0x45's table+CRC+config overhead.
+	cstMinBitmapForCompression = 32
 	cstMinHuff0BlockLog2       = 5
 	cstMaxHuff0BlockLog2       = 17
 	// cstOwnTableBias penalizes picking a per-block (non-shared) table so the
@@ -25,11 +29,88 @@ const (
 	cstOwnTableBias = 8
 )
 
+// sparseBitTableEstimate returns an upper bound on the byte count
+// appendSparseBitTable would produce for a bitmap with the given size and
+// popcount. For uniformly distributed bits the estimate is tight (within
+// a byte or two of actual).
+//
+// Derivation: each set bit contributes one final byte to its gap encoding,
+// plus floor(gap/255) "255" bytes. Sum of gaps = position[k-1] - (k-1) ≤
+// N_bits - k. So total ≤ k + (N_bits - k)/255.
+func sparseBitTableEstimate(bitmapBytes, popcount int) int {
+	nBits := bitmapBytes * 8
+	if popcount >= nBits {
+		return popcount
+	}
+	return popcount + (nBits-popcount)/255
+}
+
+// appendSparseBitTable encodes set-bit positions in bitmap as variable-length
+// gaps. Each gap < 255 emits one byte; longer gaps emit 255 bytes for each
+// full 255 and then a final byte < 255 for the remainder. The encoding is
+// terminated implicitly by the chunk's length prefix.
+//
+// bitmap length must be a multiple of 8. Reads 8 bytes at a time as a
+// little-endian uint64 and uses TrailingZeros64 to skip directly between
+// set bits — one inner-loop iteration per set bit, not per bit position.
+func appendSparseBitTable(dst, bitmap []byte) []byte {
+	gap := 0
+	for i := 0; i+8 <= len(bitmap); i += 8 {
+		v := binary.LittleEndian.Uint64(bitmap[i:])
+		if v == 0 {
+			gap += 64
+			continue
+		}
+		pos := 0
+		for v != 0 {
+			tz := bits.TrailingZeros64(v)
+			gap += tz - pos
+			for gap >= 255 {
+				dst = append(dst, 255)
+				gap -= 255
+			}
+			dst = append(dst, byte(gap))
+			gap = 0
+			pos = tz + 1
+			v &= v - 1 // clear lowest set bit
+		}
+		gap += 64 - pos
+	}
+	return dst
+}
+
+// decodeSparseBitTable populates dst (assumed pre-zeroed and sized to the
+// bitmap length) from src using the sparse-bit-table format.
+func decodeSparseBitTable(dst, src []byte) error {
+	totalBits := len(dst) * 8
+	pos := 0
+	gap := 0
+	for _, b := range src {
+		gap += int(b)
+		if b == 255 {
+			continue
+		}
+		pos += gap
+		if pos >= totalBits {
+			return fmt.Errorf("minlz: sparse bit table position %d out of range (max %d)", pos, totalBits-1)
+		}
+		dst[pos>>3] |= 1 << (pos & 7)
+		pos++
+		gap = 0
+	}
+	if gap != 0 {
+		// Trailing 255-bytes without a terminator.
+		return fmt.Errorf("minlz: sparse bit table truncated (pending gap %d)", gap)
+	}
+	return nil
+}
+
 // CompressedSearchStats reports per-bitmap stats produced by the compressed
 // search-table encoder. It is delivered via CompressedSearchStatsHook.
 type CompressedSearchStats struct {
 	BitmapBytes    int
-	Huff0BlockSize int // 1<<h0_bs, or 0 if SkippedBand or below minimum size
+	Reductions     uint8 // reductions applied to the bitmap before encoding
+	Huff0BlockSize int   // 1<<h0_bs, or 0 if SkippedBand or below minimum size
 	Huff0Blocks    int
 	SetBits        int
 	TotalBits      int
@@ -45,6 +126,7 @@ type CompressedSearchStats struct {
 	BlocksGlobalTable int
 	BlocksRaw         int
 	BlocksRLE         int
+	BlocksSparse      int
 
 	// Per-disposition on-wire payload bytes (excludes disposition byte;
 	// includes the uvarint length for table-using blocks).
@@ -52,6 +134,7 @@ type CompressedSearchStats struct {
 	BytesGlobalPayload int
 	BytesRawPayload    int
 	BytesRLEPayload    int
+	BytesSparsePayload int
 
 	// Bytes consumed by serialized table headers (sums over the tables that
 	// were actually embedded in the chunk).
@@ -100,9 +183,10 @@ func CompressedSearchForce() CompressedSearchOption {
 // huff0BlockSize picks the huff0 block partition for a bitmap of the given
 // byte length. Returns (log2(blockSize), nBlocks) with nBlocks ≤ 16.
 // Policy:
-//   bitmap ≤ 32 KiB: single block of size = bitmap.
-//   bitmap ≤ 512 KiB: 32 KiB blocks.
-//   else: 64 KiB blocks (caps at 16 blocks for the 1 MiB max bitmap).
+//
+//	bitmap ≤ 32 KiB: single block of size = bitmap.
+//	bitmap ≤ 512 KiB: 32 KiB blocks.
+//	else: 64 KiB blocks (caps at 16 blocks for the 1 MiB max bitmap).
 func huff0BlockSize(bitmapLen int) (log2bs uint8, nBlocks int) {
 	if bitmapLen <= 32<<10 {
 		return uint8(bits.Len(uint(bitmapLen) - 1)), 1
@@ -177,6 +261,9 @@ type cstEncoder struct {
 	// globalData[i] holds the data compressed using the global table for
 	// block i (filled only for blocks that were assigned the global table).
 	globalData [cstMaxHuff0Tables][]byte
+	// sparseBufs[i] holds the actual sparse-bit-table encoding for block i
+	// (filled only for blocks that were assigned the sparse disposition).
+	sparseBufs [cstMaxHuff0Tables][]byte
 	// scratch byte slice used while emitting the final chunk.
 	chunkBuf []byte
 }
@@ -189,6 +276,7 @@ func (e *cstEncoder) reset(n int) {
 		e.outTable[i] = e.outTable[i][:0]
 		e.outData[i] = e.outData[i][:0]
 		e.globalData[i] = e.globalData[i][:0]
+		e.sparseBufs[i] = e.sparseBufs[i][:0]
 	}
 	e.globalTableBytes = e.globalTableBytes[:0]
 	e.chunkBuf = e.chunkBuf[:0]
@@ -213,6 +301,7 @@ func appendSearchTableCompressedChunk(dst []byte, cfg *SearchTableConfig, reduct
 
 	stats := CompressedSearchStats{
 		BitmapBytes:   len(bitmap),
+		Reductions:    reductions,
 		SetBits:       setBits,
 		TotalBits:     totalBits,
 		Chunk0x45Size: chunk45Size,
@@ -334,6 +423,9 @@ func appendSearchTableCompressedChunk(dst []byte, cfg *SearchTableConfig, reduct
 		// For "with global" decision:
 		globalEst     int // estimated compressed bytes; -1 if cannot use
 		globalPayload int // 1 + uvarint(est) + est ; -1 if cannot use
+		// Sparse bit table (no shared state, no decoder setup).
+		sparseLen     int // bytes the sparse encoding would produce
+		sparsePayload int // 1 + uvarint(sparseLen) + sparseLen
 	}
 	costs := make([]blockCost, nBlocks)
 	rleAble := func(h *[256]uint32) (byte, bool) {
@@ -365,6 +457,12 @@ func appendSearchTableCompressedChunk(dst []byte, cfg *SearchTableConfig, reduct
 		} else {
 			c.ownPayload = -1
 		}
+		// Sparse size estimate from popcount only (O(N/8) via 64-bit popcount).
+		// The exact byte count is computed at emission time, at which point
+		// the chunk header is patched to reflect actuals.
+		popcount := popcountBytes(bitmap[i*bsize : (i+1)*bsize])
+		c.sparseLen = sparseBitTableEstimate(bsize, popcount)
+		c.sparsePayload = 1 + uvarintLen(c.sparseLen) + c.sparseLen
 		if globalAvailable && e.globalSc.CanUseTable(&e.hist[i]) {
 			c.globalEst = e.globalSc.EstimateSize(&e.hist[i])
 			c.globalPayload = 1 + uvarintLen(c.globalEst) + c.globalEst
@@ -393,6 +491,13 @@ func appendSearchTableCompressedChunk(dst []byte, cfg *SearchTableConfig, reduct
 		if c.rlePayload > 0 && c.rlePayload < bestEff {
 			best = pick{kind: cstDispRLE, size: c.rlePayload}
 			bestEff = c.rlePayload
+		}
+		// Sparse: no shared state, no table header; check after RLE so an
+		// all-zero / all-one bitmap (which fits both) prefers RLE's simpler
+		// decode.
+		if c.sparsePayload < bestEff {
+			best = pick{kind: cstDispSparse, size: c.sparsePayload}
+			bestEff = c.sparsePayload
 		}
 		if c.ownPayload > 0 {
 			// Bias non-shared tables so they only win when they save more than
@@ -565,6 +670,16 @@ func appendSearchTableCompressedChunk(dst []byte, cfg *SearchTableConfig, reduct
 		}
 	}
 
+	// Pre-emit sparse blocks so we know the actual byte count (selection used
+	// an O(1) upper-bound estimate; emission needs the exact length).
+	for i := 0; i < nBlocks; i++ {
+		if finalPicks[i].kind == cstDispSparse {
+			e.sparseBufs[i] = appendSparseBitTable(e.sparseBufs[i][:0], bitmap[i*bsize:(i+1)*bsize])
+			actual := len(e.sparseBufs[i])
+			finalPicks[i].size = 1 + uvarintLen(actual) + actual
+		}
+	}
+
 	// Compute final payload size & compare to 0x45.
 	tablesSize := 0
 	for _, t := range tableList {
@@ -597,6 +712,9 @@ func appendSearchTableCompressedChunk(dst []byte, cfg *SearchTableConfig, reduct
 		case cstDispRLE:
 			stats.BlocksRLE++
 			stats.BytesRLEPayload++ // 1-byte RLE symbol
+		case cstDispSparse:
+			stats.BlocksSparse++
+			stats.BytesSparsePayload += payload
 		}
 	}
 	for _, t := range tableList {
@@ -642,6 +760,10 @@ func appendSearchTableCompressedChunk(dst []byte, cfg *SearchTableConfig, reduct
 			dst = append(dst, bitmap[i*bsize:(i+1)*bsize]...)
 		case cstDispRLE:
 			dst = append(dst, cstDispRLE, costs[i].rleSym)
+		case cstDispSparse:
+			dst = append(dst, cstDispSparse)
+			dst = binary.AppendUvarint(dst, uint64(len(e.sparseBufs[i])))
+			dst = append(dst, e.sparseBufs[i]...)
 		}
 	}
 
@@ -658,10 +780,16 @@ type cstDecoder struct {
 	// caller via parseSearchTableCompressed; the next call re-slices it.
 	bitmapBuf []byte
 	// last parse stats (populated by parseSearchTableCompressed)
-	lastTables    int // number of huff0 tables emitted in the chunk
-	lastBlocks    int // number of huff0 sub-blocks
-	lastBlocksRaw int // sub-blocks with disposition = raw
-	lastBlocksRLE int // sub-blocks with disposition = RLE
+	lastTables           int // number of huff0 tables emitted in the chunk
+	lastBlocks           int // number of huff0 sub-blocks
+	lastBlocksRaw        int // sub-blocks with disposition = raw
+	lastBlocksRLE        int // sub-blocks with disposition = RLE
+	lastBlocksSparse     int // sub-blocks with disposition = sparse bit table
+	lastBytesTabled      int // sum of (uvarint + data) bytes for tabled blocks
+	lastBytesRaw         int // sum of raw payload bytes
+	lastBytesRLE         int // sum of RLE payload bytes (1 per block)
+	lastBytesSparse      int // sum of (uvarint + data) bytes for sparse blocks
+	lastBytesTableHeader int // sum of serialized huff0 table-header bytes
 }
 
 func newCSTDecoder() *cstDecoder { return &cstDecoder{} }
@@ -717,13 +845,16 @@ func parseSearchTableCompressed(payload []byte, dec *cstDecoder, ignoreCRC bool)
 		dec = newCSTDecoder()
 	}
 	rem := payload[off:]
+	dec.lastBytesTableHeader = 0
 	for i := 0; i < tc; i++ {
 		dec.tableSc[i].Out = dec.tableSc[i].Out[:0]
+		before := len(rem)
 		_, after, err2 := huff0.ReadTable(rem, &dec.tableSc[i])
 		if err2 != nil {
 			err = fmt.Errorf("minlz: huff0 ReadTable[%d]: %w", i, err2)
 			return
 		}
+		dec.lastBytesTableHeader += before - len(after)
 		dec.tableValid[i] = true
 		dec.decoders[i] = dec.tableSc[i].Decoder()
 		rem = after
@@ -751,6 +882,11 @@ func parseSearchTableCompressed(payload []byte, dec *cstDecoder, ignoreCRC bool)
 	dec.lastBlocks = nBlocks
 	dec.lastBlocksRaw = 0
 	dec.lastBlocksRLE = 0
+	dec.lastBlocksSparse = 0
+	dec.lastBytesTabled = 0
+	dec.lastBytesRaw = 0
+	dec.lastBytesRLE = 0
+	dec.lastBytesSparse = 0
 	for i := 0; i < nBlocks; i++ {
 		if len(rem) < 1 {
 			err = fmt.Errorf("minlz: truncated chunk at block %d disposition", i)
@@ -777,6 +913,7 @@ func parseSearchTableCompressed(payload []byte, dec *cstDecoder, ignoreCRC bool)
 			nInt := int(n)
 			jobs[i] = job{dst: dst, src: rem[nl : nl+nInt], ti: ti}
 			rem = rem[nl+nInt:]
+			dec.lastBytesTabled += nl + nInt
 		case ti == cstDispRaw:
 			if len(rem) < blockSize {
 				err = fmt.Errorf("minlz: block %d raw payload truncated", i)
@@ -785,6 +922,7 @@ func parseSearchTableCompressed(payload []byte, dec *cstDecoder, ignoreCRC bool)
 			jobs[i] = job{dst: dst, src: rem[:blockSize], ti: ti}
 			rem = rem[blockSize:]
 			dec.lastBlocksRaw++
+			dec.lastBytesRaw += blockSize
 		case ti == cstDispRLE:
 			if len(rem) < 1 {
 				err = fmt.Errorf("minlz: block %d RLE payload truncated", i)
@@ -793,6 +931,18 @@ func parseSearchTableCompressed(payload []byte, dec *cstDecoder, ignoreCRC bool)
 			jobs[i] = job{dst: dst, ti: ti, rle: rem[0]}
 			rem = rem[1:]
 			dec.lastBlocksRLE++
+			dec.lastBytesRLE++
+		case ti == cstDispSparse:
+			n, nl := binary.Uvarint(rem)
+			if nl <= 0 || nl > len(rem) || n > uint64(len(rem)-nl) {
+				err = fmt.Errorf("minlz: block %d invalid sparse length", i)
+				return
+			}
+			nInt := int(n)
+			jobs[i] = job{dst: dst, src: rem[nl : nl+nInt], ti: ti}
+			rem = rem[nl+nInt:]
+			dec.lastBlocksSparse++
+			dec.lastBytesSparse += nl + nInt
 		default:
 			err = fmt.Errorf("minlz: invalid disposition %d", ti)
 			return
@@ -818,6 +968,16 @@ func parseSearchTableCompressed(payload []byte, dec *cstDecoder, ignoreCRC bool)
 		case j.ti == cstDispRLE:
 			for k := range j.dst {
 				j.dst[k] = j.rle
+			}
+		case j.ti == cstDispSparse:
+			// dst is a slice of the (already-zeroed) bitmapBuf; decodeSparseBitTable
+			// will OR in the set bits. The slice has cap == len so reuse-from-prior
+			// chunk is safe — the slice's window is exclusive to this huff0 block.
+			for k := range j.dst {
+				j.dst[k] = 0
+			}
+			if e := decodeSparseBitTable(j.dst, j.src); e != nil {
+				return e
 			}
 		}
 		return nil

--- a/search_compressed.go
+++ b/search_compressed.go
@@ -15,7 +15,7 @@ const (
 	cstDispRLE                = 17
 	cstDispSparse             = 18
 	cstMaxHuff0Tables         = 16
-	cstDefaultSkipPctTimes100 = 1000 // 5.00%
+	cstDefaultSkipPctTimes100 = 1000 // 10.00%
 	// Absolute minimum bitmap that 0x46 can wrap (= smallest search table = 32 B).
 	// huff0 may fail to compress at this size, but the RLE / sparse / raw
 	// fallbacks still win against 0x45's table+CRC+config overhead.

--- a/search_compressed.go
+++ b/search_compressed.go
@@ -1,0 +1,862 @@
+package minlz
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/bits"
+	"sync"
+
+	"github.com/klauspost/compress/huff0"
+)
+
+const (
+	cstDispRaw                 = 16
+	cstDispRLE                 = 17
+	cstMaxHuff0Tables          = 16
+	cstDefaultSkipPctTimes100  = 1000 // 5.00%
+	cstMinBitmapForCompression = 64   // huff0.Compress4X requires >= 12 bytes; below this the table overhead dwarfs savings
+	cstMinHuff0BlockLog2       = 5
+	cstMaxHuff0BlockLog2       = 17
+	// cstOwnTableBias penalizes picking a per-block (non-shared) table so the
+	// encoder only emits one when it saves strictly more than this many bytes
+	// vs the next-best alternative (raw / RLE / global). Smaller table count
+	// = faster decoder setup.
+	cstOwnTableBias = 8
+)
+
+// CompressedSearchStats reports per-bitmap stats produced by the compressed
+// search-table encoder. It is delivered via CompressedSearchStatsHook.
+type CompressedSearchStats struct {
+	BitmapBytes    int
+	Huff0BlockSize int // 1<<h0_bs, or 0 if SkippedBand or below minimum size
+	Huff0Blocks    int
+	SetBits        int
+	TotalBits      int
+	SkippedBand    bool // popcount band rejected compression
+	SkippedSize    bool // bitmap below cstMinBitmapForCompression
+	Chunk0x45Size  int  // alternative uncompressed-form size
+	Chunk0x46Size  int  // produced compressed-form size; 0 if not emitted
+	Emitted0x46    bool
+	Tables         int // distinct tables embedded
+
+	// Per-disposition sub-block counts (sum to Huff0Blocks when emitted).
+	BlocksOwnTable    int
+	BlocksGlobalTable int
+	BlocksRaw         int
+	BlocksRLE         int
+
+	// Per-disposition on-wire payload bytes (excludes disposition byte;
+	// includes the uvarint length for table-using blocks).
+	BytesOwnPayload    int
+	BytesGlobalPayload int
+	BytesRawPayload    int
+	BytesRLEPayload    int
+
+	// Bytes consumed by serialized table headers (sums over the tables that
+	// were actually embedded in the chunk).
+	BytesOwnTables   int
+	BytesGlobalTable int
+}
+
+type compressedOpts struct {
+	enabled         bool
+	skipPctTimes100 int
+	statsHook       func(CompressedSearchStats)
+	forceCompressed bool
+}
+
+// CompressedSearchOption configures the compressed search-table encoder.
+type CompressedSearchOption func(*compressedOpts)
+
+// CompressedSearchSkipPct sets the popcount-band half-width (in percent) below
+// which compression is skipped. The default is 5.0.
+func CompressedSearchSkipPct(pct float64) CompressedSearchOption {
+	return func(o *compressedOpts) {
+		if pct < 0 {
+			pct = 0
+		}
+		if pct > 50 {
+			pct = 50
+		}
+		o.skipPctTimes100 = int(pct * 100)
+	}
+}
+
+// CompressedSearchStatsHook installs a callback receiving stats for every
+// search-table bitmap processed by the encoder. The callback must not retain
+// references into the supplied struct.
+func CompressedSearchStatsHook(fn func(CompressedSearchStats)) CompressedSearchOption {
+	return func(o *compressedOpts) { o.statsHook = fn }
+}
+
+// CompressedSearchForce forces the encoder to emit the compressed chunk type
+// (0x46) even when it is larger than the uncompressed (0x45) alternative.
+// Intended for benchmarking only.
+func CompressedSearchForce() CompressedSearchOption {
+	return func(o *compressedOpts) { o.forceCompressed = true }
+}
+
+// huff0BlockSize picks the huff0 block partition for a bitmap of the given
+// byte length. Returns (log2(blockSize), nBlocks) with nBlocks ≤ 16.
+// Policy:
+//   bitmap ≤ 32 KiB: single block of size = bitmap.
+//   bitmap ≤ 512 KiB: 32 KiB blocks.
+//   else: 64 KiB blocks (caps at 16 blocks for the 1 MiB max bitmap).
+func huff0BlockSize(bitmapLen int) (log2bs uint8, nBlocks int) {
+	if bitmapLen <= 32<<10 {
+		return uint8(bits.Len(uint(bitmapLen) - 1)), 1
+	}
+	if bitmapLen <= 16*32<<10 {
+		return 15, bitmapLen >> 15
+	}
+	return 16, bitmapLen >> 16
+}
+
+func uvarintLen(n int) int {
+	if n < 0 {
+		return 0
+	}
+	switch {
+	case n < 1<<7:
+		return 1
+	case n < 1<<14:
+		return 2
+	case n < 1<<21:
+		return 3
+	case n < 1<<28:
+		return 4
+	default:
+		return 5
+	}
+}
+
+func popcountBytes(b []byte) int {
+	n := 0
+	// Process 8 bytes at a time when possible.
+	i := 0
+	for ; i+8 <= len(b); i += 8 {
+		v := binary.LittleEndian.Uint64(b[i:])
+		n += bits.OnesCount64(v)
+	}
+	for ; i < len(b); i++ {
+		n += bits.OnesCount8(b[i])
+	}
+	return n
+}
+
+func absInt(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+// cstEncoder holds per-stream-worker state for compressing search bitmaps.
+// One encoder must be used from a single goroutine at a time (it owns the
+// huff0 scratches and output buffers); concurrency in the Writer is achieved
+// via a sync.Pool of cstEncoder instances.
+type cstEncoder struct {
+	perBlockSc [cstMaxHuff0Tables]huff0.Scratch
+	globalSc   huff0.Scratch
+	// workSc is used to compress against a transferred (global or shared)
+	// table without disturbing perBlockSc state.
+	workSc huff0.Scratch
+	// Per-block buffers preserved across blocks. Compress4X writes into
+	// Scratch.Out — slicing OutTable/OutData out of it remains valid until
+	// the next Compress on that Scratch.
+	// hist[i] is the byte histogram for block i.
+	hist [cstMaxHuff0Tables][256]uint32
+	// outTable[i], outData[i] are owned copies (we copy out of OutTable/OutData
+	// to detach from Scratch.Out so the same Scratch can be reused for
+	// global-table compression in the next phase).
+	outTable [cstMaxHuff0Tables][]byte
+	outData  [cstMaxHuff0Tables][]byte
+	// globalTableBytes holds the serialized global huff0 table header.
+	globalTableBytes []byte
+	// globalData[i] holds the data compressed using the global table for
+	// block i (filled only for blocks that were assigned the global table).
+	globalData [cstMaxHuff0Tables][]byte
+	// scratch byte slice used while emitting the final chunk.
+	chunkBuf []byte
+}
+
+func newCSTEncoder() *cstEncoder { return &cstEncoder{} }
+
+func (e *cstEncoder) reset(n int) {
+	for i := 0; i < n; i++ {
+		e.hist[i] = [256]uint32{}
+		e.outTable[i] = e.outTable[i][:0]
+		e.outData[i] = e.outData[i][:0]
+		e.globalData[i] = e.globalData[i][:0]
+	}
+	e.globalTableBytes = e.globalTableBytes[:0]
+	e.chunkBuf = e.chunkBuf[:0]
+}
+
+// appendSearchTableCompressedChunk evaluates the compressed (0x46) chunk form
+// and emits it when strictly smaller than the uncompressed (0x45) chunk form
+// (unless co.forceCompressed). Returns:
+//   - (newDst, true, nil) when 0x46 was emitted to dst.
+//   - (nil, false, nil) when 0x45 should be emitted instead (band skip,
+//     bitmap too small, compression unhelpful, etc).
+//   - (nil, false, err) on internal error.
+func appendSearchTableCompressedChunk(dst []byte, cfg *SearchTableConfig, reductions uint8, bitmap []byte, e *cstEncoder) ([]byte, bool, error) {
+	co := cfg.compression
+	if co == nil || !co.enabled || e == nil {
+		return nil, false, nil
+	}
+
+	setBits := popcountBytes(bitmap)
+	totalBits := len(bitmap) * 8
+	chunk45Size := 4 + cfg.searchTablePayloadSize(len(bitmap))
+
+	stats := CompressedSearchStats{
+		BitmapBytes:   len(bitmap),
+		SetBits:       setBits,
+		TotalBits:     totalBits,
+		Chunk0x45Size: chunk45Size,
+	}
+	emitStats := func() {
+		if co.statsHook != nil {
+			co.statsHook(stats)
+		}
+	}
+
+	if len(bitmap) < cstMinBitmapForCompression {
+		stats.SkippedSize = true
+		emitStats()
+		return nil, false, nil
+	}
+	// Popcount band: skip when |setBits/totalBits - 0.5| < skipPct/100.
+	// Equivalent: |2*setBits - totalBits| * 5000 < skipPctTimes100 * totalBits.
+	if absInt(2*setBits-totalBits)*5000 < co.skipPctTimes100*totalBits {
+		stats.SkippedBand = true
+		emitStats()
+		return nil, false, nil
+	}
+
+	log2bs, nBlocks := huff0BlockSize(len(bitmap))
+	bsize := 1 << log2bs
+	if nBlocks > cstMaxHuff0Tables || nBlocks*bsize != len(bitmap) || log2bs < cstMinHuff0BlockLog2 || log2bs > cstMaxHuff0BlockLog2 {
+		// Shouldn't happen for valid bitmaps; bail to 0x45.
+		return nil, false, nil
+	}
+	stats.Huff0BlockSize = bsize
+	stats.Huff0Blocks = nBlocks
+
+	e.reset(nBlocks)
+
+	// Phase 1: per-block compression with own table.
+	type runResult struct {
+		ok     bool // own table available
+		rleSym byte
+	}
+	results := make([]runResult, nBlocks)
+	runOne := func(i int) {
+		slice := bitmap[i*bsize : (i+1)*bsize]
+		// Build histogram.
+		var h [256]uint32
+		for _, b := range slice {
+			h[b]++
+		}
+		e.hist[i] = h
+		// Compress with no reuse.
+		sc := &e.perBlockSc[i]
+		sc.Reuse = huff0.ReusePolicyNone
+		sc.Out = sc.Out[:0]
+		_, _, err := huff0.Compress4X(slice, sc)
+		if err == nil {
+			// Copy out detached buffers so we can reuse sc later for global compression.
+			e.outTable[i] = append(e.outTable[i][:0], sc.OutTable...)
+			e.outData[i] = append(e.outData[i][:0], sc.OutData...)
+			results[i].ok = true
+			return
+		}
+		if errors.Is(err, huff0.ErrUseRLE) {
+			// Pick any non-zero histogram bucket as the RLE byte.
+			for s, v := range h {
+				if v > 0 {
+					results[i].rleSym = byte(s)
+					break
+				}
+			}
+		}
+		// On ErrIncompressible: results[i].ok stays false, no own table.
+	}
+
+	if nBlocks == 1 {
+		runOne(0)
+	} else {
+		var wg sync.WaitGroup
+		for i := 0; i < nBlocks; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				runOne(i)
+			}(i)
+		}
+		wg.Wait()
+	}
+
+	// Phase 2: build the global table from the summed histogram.
+	var globalSerSize int
+	var sumHist [256]uint32
+	globalAvailable := false
+	buildGlobalFrom := func(h *[256]uint32) bool {
+		if err := e.globalSc.BuildCTable(h); err != nil {
+			return false
+		}
+		tbl, err := e.globalSc.AppendTable(e.globalTableBytes[:0])
+		if err != nil {
+			return false
+		}
+		e.globalTableBytes = tbl
+		globalSerSize = len(tbl)
+		return true
+	}
+	if nBlocks > 1 {
+		for i := 0; i < nBlocks; i++ {
+			for j, v := range e.hist[i] {
+				sumHist[j] += v
+			}
+		}
+		globalAvailable = buildGlobalFrom(&sumHist)
+	}
+
+	// Per-block payload candidates.
+	type blockCost struct {
+		ownPayload   int // 1 + uvarint(len) + len  (or -1 if no own table)
+		ownTableSize int
+		rawPayload   int
+		rlePayload   int // -1 if not RLE
+		rleSym       byte
+		// For "with global" decision:
+		globalEst     int // estimated compressed bytes; -1 if cannot use
+		globalPayload int // 1 + uvarint(est) + est ; -1 if cannot use
+	}
+	costs := make([]blockCost, nBlocks)
+	rleAble := func(h *[256]uint32) (byte, bool) {
+		var sym byte
+		count := 0
+		for s, v := range h {
+			if v > 0 {
+				count++
+				if count > 1 {
+					return 0, false
+				}
+				sym = byte(s)
+			}
+		}
+		return sym, count == 1
+	}
+	for i := 0; i < nBlocks; i++ {
+		c := &costs[i]
+		c.rawPayload = 1 + bsize
+		if sym, ok := rleAble(&e.hist[i]); ok {
+			c.rleSym = sym
+			c.rlePayload = 2
+		} else {
+			c.rlePayload = -1
+		}
+		if results[i].ok {
+			c.ownPayload = 1 + uvarintLen(len(e.outData[i])) + len(e.outData[i])
+			c.ownTableSize = len(e.outTable[i])
+		} else {
+			c.ownPayload = -1
+		}
+		if globalAvailable && e.globalSc.CanUseTable(&e.hist[i]) {
+			c.globalEst = e.globalSc.EstimateSize(&e.hist[i])
+			c.globalPayload = 1 + uvarintLen(c.globalEst) + c.globalEst
+		} else {
+			c.globalEst = -1
+			c.globalPayload = -1
+		}
+	}
+
+	// Decision: compare "without global" vs "with global".
+	// Each block independently picks the cheapest disposition.
+	// pick.size is the per-block ON-WIRE payload (disposition byte + length +
+	// data). Own-table cost is tracked separately so it isn't double-counted
+	// in the chunk size.
+	type pick struct {
+		kind uint8 // 0=own, 1=global, cstDispRaw=raw, cstDispRLE=rle
+		size int   // per-block payload bytes on wire (no table contribution)
+	}
+	// pickBest returns the disposition with the smallest effective cost
+	// (payload + amortized table cost). selfCost is used purely for comparison
+	// across dispositions; the returned pick.size is the on-wire payload only.
+	pickBest := func(i int, allowGlobal bool) (pick, int) {
+		c := costs[i]
+		best := pick{kind: cstDispRaw, size: c.rawPayload}
+		bestEff := c.rawPayload
+		if c.rlePayload > 0 && c.rlePayload < bestEff {
+			best = pick{kind: cstDispRLE, size: c.rlePayload}
+			bestEff = c.rlePayload
+		}
+		if c.ownPayload > 0 {
+			// Bias non-shared tables so they only win when they save more than
+			// cstOwnTableBias bytes vs any alternative. Reduces the per-chunk
+			// table count, which is the dominant cost on the decode side.
+			eff := c.ownPayload + c.ownTableSize + cstOwnTableBias
+			if eff < bestEff {
+				best = pick{kind: 0, size: c.ownPayload}
+				bestEff = eff
+			}
+		}
+		if allowGlobal && c.globalPayload > 0 && c.globalPayload <= bestEff {
+			best = pick{kind: 1, size: c.globalPayload}
+			bestEff = c.globalPayload
+		}
+		return best, bestEff
+	}
+
+	// recomputeGlobalCosts updates each block's globalEst/globalPayload from
+	// the currently installed global table (whatever it was last built from).
+	recomputeGlobalCosts := func() {
+		for i := 0; i < nBlocks; i++ {
+			if globalAvailable && e.globalSc.CanUseTable(&e.hist[i]) {
+				costs[i].globalEst = e.globalSc.EstimateSize(&e.hist[i])
+				costs[i].globalPayload = 1 + uvarintLen(costs[i].globalEst) + costs[i].globalEst
+			} else {
+				costs[i].globalEst = -1
+				costs[i].globalPayload = -1
+			}
+		}
+	}
+
+	picksNG := make([]pick, nBlocks)
+	totalNG := 0
+	for i := 0; i < nBlocks; i++ {
+		var eff int
+		picksNG[i], eff = pickBest(i, false)
+		totalNG += eff
+	}
+
+	pickWG := func() ([]pick, int, int) {
+		out := make([]pick, nBlocks)
+		total := globalSerSize
+		users := 0
+		for i := 0; i < nBlocks; i++ {
+			var eff int
+			out[i], eff = pickBest(i, true)
+			total += eff
+			if out[i].kind == 1 {
+				users++
+			}
+		}
+		return out, total, users
+	}
+
+	picksWG, totalWG, wgUsers := pickWG()
+
+	// If ≥2 blocks would use the global table, rebuild it from just their
+	// histograms (the others' histograms only diluted the table). Commit only
+	// when the rebuild improves total bytes AND keeps ≥2 users.
+	if globalAvailable && wgUsers >= 2 {
+		var subHist [256]uint32
+		for i := 0; i < nBlocks; i++ {
+			if picksWG[i].kind == 1 {
+				for j, v := range e.hist[i] {
+					subHist[j] += v
+				}
+			}
+		}
+		if buildGlobalFrom(&subHist) {
+			recomputeGlobalCosts()
+			newPicks, newTotal, newUsers := pickWG()
+			if newUsers >= 2 && newTotal < totalWG {
+				picksWG, totalWG, wgUsers = newPicks, newTotal, newUsers
+			} else {
+				// Roll back to the all-blocks global so estimates and the
+				// committed table match what picksWG referenced.
+				buildGlobalFrom(&sumHist)
+				recomputeGlobalCosts()
+			}
+		}
+	}
+
+	// A "shared" table used by only 0 or 1 block isn't shared — treat as
+	// wasted overhead and force NG to win.
+	wgUsesGlobal := wgUsers >= 2
+	if !wgUsesGlobal {
+		totalWG = totalNG + globalSerSize
+	}
+
+	useGlobal := wgUsesGlobal && totalWG < totalNG
+	finalPicks := picksNG
+	if useGlobal {
+		finalPicks = picksWG
+	}
+
+	// Phase 3: if global table is in use, actually compress the global-using
+	// blocks against the global table to produce real data lengths.
+	if useGlobal {
+		e.workSc.TransferCTable(&e.globalSc)
+		e.workSc.Reuse = huff0.ReusePolicyMust
+		for i := 0; i < nBlocks; i++ {
+			if finalPicks[i].kind != 1 {
+				continue
+			}
+			slice := bitmap[i*bsize : (i+1)*bsize]
+			e.workSc.Out = e.workSc.Out[:0]
+			_, reused, err := huff0.Compress4X(slice, &e.workSc)
+			if err != nil || !reused {
+				// Global table didn't apply after all; downgrade this block.
+				if c := costs[i]; c.ownPayload > 0 && c.ownPayload+c.ownTableSize < c.rawPayload {
+					finalPicks[i] = pick{kind: 0, size: c.ownPayload}
+				} else if c.rlePayload > 0 && c.rlePayload < c.rawPayload {
+					finalPicks[i] = pick{kind: cstDispRLE, size: c.rlePayload}
+				} else {
+					finalPicks[i] = pick{kind: cstDispRaw, size: c.rawPayload}
+				}
+				continue
+			}
+			e.globalData[i] = append(e.globalData[i][:0], e.workSc.OutData...)
+			finalPicks[i].size = 1 + uvarintLen(len(e.globalData[i])) + len(e.globalData[i])
+		}
+	}
+
+	// Build the final table-index map and accumulate actual table bytes.
+	// Tables order in the chunk: each retained own table in block order, then
+	// the global table (if used).
+	type tableRef struct {
+		ownBlock int // index in own-tables source (or -1 for global)
+	}
+	tableList := make([]tableRef, 0, cstMaxHuff0Tables)
+	ownTableIdx := make([]int, nBlocks)
+	for i := range ownTableIdx {
+		ownTableIdx[i] = -1
+	}
+	for i := 0; i < nBlocks; i++ {
+		if finalPicks[i].kind == 0 {
+			ownTableIdx[i] = len(tableList)
+			tableList = append(tableList, tableRef{ownBlock: i})
+		}
+	}
+	globalTableIdx := -1
+	if useGlobal {
+		globalTableIdx = len(tableList)
+		tableList = append(tableList, tableRef{ownBlock: -1})
+	}
+	if len(tableList) > cstMaxHuff0Tables {
+		// Truncation case: drop the global table to make room. Re-pick blocks
+		// that were using global.
+		if useGlobal && len(tableList) == cstMaxHuff0Tables+1 {
+			globalTableIdx = -1
+			tableList = tableList[:cstMaxHuff0Tables]
+			for i := 0; i < nBlocks; i++ {
+				if finalPicks[i].kind == 1 {
+					c := costs[i]
+					if c.ownPayload > 0 && c.ownPayload+c.ownTableSize < c.rawPayload {
+						// promote to own (would also add table to list — but list is full,
+						// so fall back to raw to keep things simple in the rare case).
+						finalPicks[i] = pick{kind: cstDispRaw, size: c.rawPayload}
+					} else if c.rlePayload > 0 && c.rlePayload < c.rawPayload {
+						finalPicks[i] = pick{kind: cstDispRLE, size: c.rlePayload}
+					} else {
+						finalPicks[i] = pick{kind: cstDispRaw, size: c.rawPayload}
+					}
+				}
+			}
+		} else {
+			// Should never happen: tableList = own_n (n ≤ 16) + global = at most 17.
+			return nil, false, fmt.Errorf("minlz: too many search tables: %d", len(tableList))
+		}
+	}
+
+	// Compute final payload size & compare to 0x45.
+	tablesSize := 0
+	for _, t := range tableList {
+		if t.ownBlock >= 0 {
+			tablesSize += len(e.outTable[t.ownBlock])
+		} else {
+			tablesSize += len(e.globalTableBytes)
+		}
+	}
+	payloadSize := 3 + cfg.prefixSize() + 1 /*reductions*/ + 4 /*crc*/ + 2 /*h0_bs+h0_tc*/ + tablesSize
+	for i := 0; i < nBlocks; i++ {
+		payloadSize += finalPicks[i].size
+	}
+	totalChunkSize := 4 + payloadSize
+
+	stats.Tables = len(tableList)
+	stats.Chunk0x46Size = totalChunkSize
+	for i := 0; i < nBlocks; i++ {
+		payload := finalPicks[i].size - 1 // exclude disposition byte
+		switch finalPicks[i].kind {
+		case 0:
+			stats.BlocksOwnTable++
+			stats.BytesOwnPayload += payload
+		case 1:
+			stats.BlocksGlobalTable++
+			stats.BytesGlobalPayload += payload
+		case cstDispRaw:
+			stats.BlocksRaw++
+			stats.BytesRawPayload += bsize
+		case cstDispRLE:
+			stats.BlocksRLE++
+			stats.BytesRLEPayload++ // 1-byte RLE symbol
+		}
+	}
+	for _, t := range tableList {
+		if t.ownBlock >= 0 {
+			stats.BytesOwnTables += len(e.outTable[t.ownBlock])
+		} else {
+			stats.BytesGlobalTable = len(e.globalTableBytes)
+		}
+	}
+
+	if !co.forceCompressed && totalChunkSize >= chunk45Size {
+		emitStats()
+		return nil, false, nil
+	}
+	stats.Emitted0x46 = true
+
+	// Serialize the chunk.
+	dst = appendChunkHeader(dst, chunkTypeSearchTableCompressed, payloadSize)
+	dst = cfg.appendConfig(dst)
+	dst = append(dst, reductions)
+	dst = binary.LittleEndian.AppendUint32(dst, crc(bitmap))
+	dst = append(dst, log2bs, uint8(len(tableList)))
+	for _, t := range tableList {
+		if t.ownBlock >= 0 {
+			dst = append(dst, e.outTable[t.ownBlock]...)
+		} else {
+			dst = append(dst, e.globalTableBytes...)
+		}
+	}
+	for i := 0; i < nBlocks; i++ {
+		p := finalPicks[i]
+		switch p.kind {
+		case 0:
+			dst = append(dst, uint8(ownTableIdx[i]))
+			dst = binary.AppendUvarint(dst, uint64(len(e.outData[i])))
+			dst = append(dst, e.outData[i]...)
+		case 1:
+			dst = append(dst, uint8(globalTableIdx))
+			dst = binary.AppendUvarint(dst, uint64(len(e.globalData[i])))
+			dst = append(dst, e.globalData[i]...)
+		case cstDispRaw:
+			dst = append(dst, cstDispRaw)
+			dst = append(dst, bitmap[i*bsize:(i+1)*bsize]...)
+		case cstDispRLE:
+			dst = append(dst, cstDispRLE, costs[i].rleSym)
+		}
+	}
+
+	emitStats()
+	return dst, true, nil
+}
+
+// cstDecoder holds reusable state for decoding 0x46 chunks.
+type cstDecoder struct {
+	tableSc    [cstMaxHuff0Tables]huff0.Scratch
+	tableValid [cstMaxHuff0Tables]bool
+	decoders   [cstMaxHuff0Tables]*huff0.Decoder
+	// bitmapBuf is the reusable decoded-bitmap output. Returned to the
+	// caller via parseSearchTableCompressed; the next call re-slices it.
+	bitmapBuf []byte
+	// last parse stats (populated by parseSearchTableCompressed)
+	lastTables    int // number of huff0 tables emitted in the chunk
+	lastBlocks    int // number of huff0 sub-blocks
+	lastBlocksRaw int // sub-blocks with disposition = raw
+	lastBlocksRLE int // sub-blocks with disposition = RLE
+}
+
+func newCSTDecoder() *cstDecoder { return &cstDecoder{} }
+
+// parseSearchTableCompressed parses a 0x46 chunk payload (the bytes after the
+// 4-byte chunk header) and reconstructs the uncompressed bitmap. The returned
+// table slice is freshly allocated; callers are responsible for any pooling.
+func parseSearchTableCompressed(payload []byte, dec *cstDecoder, ignoreCRC bool) (cfg SearchTableConfig, reductions uint8, table []byte, err error) {
+	cfg, err = parseSearchInfo(payload)
+	if err != nil {
+		return
+	}
+	off := 3 + cfg.prefixSize()
+	if off+1+4+2 > len(payload) {
+		err = fmt.Errorf("minlz: compressed search table chunk too short for header")
+		return
+	}
+	reductions = payload[off]
+	off++
+	crc32 := binary.LittleEndian.Uint32(payload[off:])
+	off += 4
+	log2bs := payload[off]
+	off++
+	tc := int(payload[off])
+	off++
+
+	if log2bs < cstMinHuff0BlockLog2 || log2bs > cstMaxHuff0BlockLog2 {
+		err = fmt.Errorf("minlz: invalid huff0 block log2 %d", log2bs)
+		return
+	}
+	if tc > cstMaxHuff0Tables {
+		err = fmt.Errorf("minlz: invalid huff0 table count %d", tc)
+		return
+	}
+	if cfg.baseTableSize <= reductions+3 {
+		err = fmt.Errorf("minlz: invalid reductions %d for baseTableSize %d", reductions, cfg.baseTableSize)
+		return
+	}
+	expectedSize := 1 << (cfg.baseTableSize - reductions - 3)
+	blockSize := 1 << log2bs
+	if expectedSize%blockSize != 0 {
+		err = fmt.Errorf("minlz: bitmap size %d not divisible by huff0 block size %d", expectedSize, blockSize)
+		return
+	}
+	nBlocks := expectedSize / blockSize
+	if nBlocks < 1 || nBlocks > cstMaxHuff0Tables {
+		err = fmt.Errorf("minlz: invalid huff0 block count %d", nBlocks)
+		return
+	}
+
+	// Parse tables.
+	if dec == nil {
+		dec = newCSTDecoder()
+	}
+	rem := payload[off:]
+	for i := 0; i < tc; i++ {
+		dec.tableSc[i].Out = dec.tableSc[i].Out[:0]
+		_, after, err2 := huff0.ReadTable(rem, &dec.tableSc[i])
+		if err2 != nil {
+			err = fmt.Errorf("minlz: huff0 ReadTable[%d]: %w", i, err2)
+			return
+		}
+		dec.tableValid[i] = true
+		dec.decoders[i] = dec.tableSc[i].Decoder()
+		rem = after
+	}
+	// Invalidate unused decoders from a prior chunk.
+	for i := tc; i < cstMaxHuff0Tables; i++ {
+		dec.tableValid[i] = false
+		dec.decoders[i] = nil
+	}
+
+	// Parse per-block records (sequentially) and decompress (concurrently).
+	type job struct {
+		dst []byte
+		src []byte
+		ti  uint8
+		rle byte
+	}
+	if cap(dec.bitmapBuf) < expectedSize {
+		dec.bitmapBuf = make([]byte, expectedSize)
+	}
+	table = dec.bitmapBuf[:expectedSize]
+	jobs := make([]job, nBlocks)
+	// Reset per-parse stats.
+	dec.lastTables = tc
+	dec.lastBlocks = nBlocks
+	dec.lastBlocksRaw = 0
+	dec.lastBlocksRLE = 0
+	for i := 0; i < nBlocks; i++ {
+		if len(rem) < 1 {
+			err = fmt.Errorf("minlz: truncated chunk at block %d disposition", i)
+			return
+		}
+		ti := rem[0]
+		rem = rem[1:]
+		// 3-index slice limits cap to blockSize so huff0.Decompress4X computes
+		// the right per-stream length (it uses cap(dst), not len(dst)).
+		dst := table[i*blockSize : (i+1)*blockSize : (i+1)*blockSize]
+		switch {
+		case ti <= 15:
+			if int(ti) >= tc {
+				err = fmt.Errorf("minlz: block %d references unknown table %d", i, ti)
+				return
+			}
+			n, nl := binary.Uvarint(rem)
+			// Compare in uint64 space: an attacker-supplied uvarint can be > 2^63,
+			// and casting to int first would wrap to negative.
+			if nl <= 0 || nl > len(rem) || n > uint64(len(rem)-nl) {
+				err = fmt.Errorf("minlz: block %d invalid compressed length", i)
+				return
+			}
+			nInt := int(n)
+			jobs[i] = job{dst: dst, src: rem[nl : nl+nInt], ti: ti}
+			rem = rem[nl+nInt:]
+		case ti == cstDispRaw:
+			if len(rem) < blockSize {
+				err = fmt.Errorf("minlz: block %d raw payload truncated", i)
+				return
+			}
+			jobs[i] = job{dst: dst, src: rem[:blockSize], ti: ti}
+			rem = rem[blockSize:]
+			dec.lastBlocksRaw++
+		case ti == cstDispRLE:
+			if len(rem) < 1 {
+				err = fmt.Errorf("minlz: block %d RLE payload truncated", i)
+				return
+			}
+			jobs[i] = job{dst: dst, ti: ti, rle: rem[0]}
+			rem = rem[1:]
+			dec.lastBlocksRLE++
+		default:
+			err = fmt.Errorf("minlz: invalid disposition %d", ti)
+			return
+		}
+	}
+	if len(rem) != 0 {
+		err = fmt.Errorf("minlz: trailing %d bytes after chunk", len(rem))
+		return
+	}
+
+	doJob := func(j job) error {
+		switch {
+		case j.ti <= 15:
+			out, derr := dec.decoders[j.ti].Decompress4X(j.dst[:0], j.src)
+			if derr != nil {
+				return derr
+			}
+			if len(out) != len(j.dst) {
+				return fmt.Errorf("minlz: decompressed length %d != expected %d", len(out), len(j.dst))
+			}
+		case j.ti == cstDispRaw:
+			copy(j.dst, j.src)
+		case j.ti == cstDispRLE:
+			for k := range j.dst {
+				j.dst[k] = j.rle
+			}
+		}
+		return nil
+	}
+
+	if nBlocks == 1 {
+		if derr := doJob(jobs[0]); derr != nil {
+			err = derr
+			return
+		}
+	} else {
+		var wg sync.WaitGroup
+		var derrMu sync.Mutex
+		var derr error
+		for _, j := range jobs {
+			wg.Add(1)
+			go func(j job) {
+				defer wg.Done()
+				if e := doJob(j); e != nil {
+					derrMu.Lock()
+					if derr == nil {
+						derr = e
+					}
+					derrMu.Unlock()
+				}
+			}(j)
+		}
+		wg.Wait()
+		if derr != nil {
+			err = derr
+			return
+		}
+	}
+
+	if !ignoreCRC && crc(table) != crc32 {
+		err = fmt.Errorf("minlz: compressed search table CRC mismatch")
+		return
+	}
+	return
+}
+
+var cstEncoderPool = sync.Pool{New: func() any { return newCSTEncoder() }}

--- a/search_compressed.go
+++ b/search_compressed.go
@@ -319,7 +319,9 @@ func appendSearchTableCompressedChunk(dst []byte, cfg *SearchTableConfig, reduct
 	}
 	// Popcount band: skip when |setBits/totalBits - 0.5| < skipPct/100.
 	// Equivalent: |2*setBits - totalBits| * 5000 < skipPctTimes100 * totalBits.
-	if absInt(2*setBits-totalBits)*5000 < co.skipPctTimes100*totalBits {
+	// Computed in int64 — totalBits can be up to 8 MiB so the int32-product
+	// would overflow on 32-bit GOARCH.
+	if int64(absInt(2*setBits-totalBits))*5000 < int64(co.skipPctTimes100)*int64(totalBits) {
 		stats.SkippedBand = true
 		emitStats()
 		return nil, false, nil

--- a/search_compressed_test.go
+++ b/search_compressed_test.go
@@ -156,15 +156,23 @@ func TestCompressedPopcountBand(t *testing.T) {
 	}
 }
 
-func TestCompressedSkippedForTinyBitmap(t *testing.T) {
+func TestCompressedTinyBitmapBeats45(t *testing.T) {
+	// A 32-byte all-zero bitmap should be emitted as 0x46 via the RLE path
+	// (≈16 bytes) instead of the ≈44-byte 0x45 form.
 	bitmap := make([]byte, 32)
-	bitmap[0] = 0x01
 	cfg := NewSearchTableConfig().WithMatchLen(4).WithCompression()
 	cfg.baseTableSize = 8
 	e := newCSTEncoder()
-	_, ok, _ := appendSearchTableCompressedChunk(nil, &cfg, 0, bitmap, e)
-	if ok {
-		t.Fatalf("expected size rejection for tiny bitmap")
+	out, ok, err := appendSearchTableCompressedChunk(nil, &cfg, 0, bitmap, e)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected 0x46 emission for tiny sparse bitmap")
+	}
+	chunk45 := 4 + cfg.searchTablePayloadSize(len(bitmap))
+	if len(out) >= chunk45 {
+		t.Fatalf("0x46 chunk (%d) not smaller than 0x45 (%d)", len(out), chunk45)
 	}
 }
 
@@ -215,6 +223,224 @@ func TestCompressedRLEAllOne(t *testing.T) {
 	}
 	if !bytes.Equal(got, bitmap) {
 		t.Fatalf("roundtrip mismatch")
+	}
+}
+
+// TestCompressedGlobalSingleUserWasted constructs a multi-block bitmap where
+// only one huff0 block could plausibly use the global table (the rest are
+// all-zero → RLE). The encoder should reject the global table because a
+// single user is not actually sharing.
+func TestCompressedGlobalSingleUserWasted(t *testing.T) {
+	const sz = 64 << 10 // 2 huff0 blocks of 32 KiB
+	bitmap := make([]byte, sz)
+	rng := rand.New(rand.NewSource(11))
+	// Block 0: skewed random data — Compress4X will succeed.
+	for i := 0; i < 32<<10; i++ {
+		bitmap[i] = byte(rng.Intn(16))
+	}
+	// Block 1: all zeros → forced to RLE.
+
+	cfg := NewSearchTableConfig().WithMatchLen(4)
+	cfg.baseTableSize = 19 // 1<<(19-3) = 64 KiB
+	var seen CompressedSearchStats
+	cfg = cfg.WithCompression(CompressedSearchForce(),
+		CompressedSearchStatsHook(func(s CompressedSearchStats) { seen = s }))
+	e := newCSTEncoder()
+	out, ok, err := appendSearchTableCompressedChunk(nil, &cfg, 0, bitmap, e)
+	if err != nil || !ok {
+		t.Fatalf("append err=%v ok=%v", err, ok)
+	}
+	// Block 1 must be RLE; block 0 picks own or raw — never global, since
+	// global having a single user is treated as wasted.
+	if seen.BlocksGlobalTable != 0 {
+		t.Fatalf("expected 0 global users (single-user is wasted), got %d (own=%d raw=%d RLE=%d sparse=%d)",
+			seen.BlocksGlobalTable, seen.BlocksOwnTable, seen.BlocksRaw, seen.BlocksRLE, seen.BlocksSparse)
+	}
+	// Roundtrip sanity.
+	_, _, got, err := parseSearchTableCompressed(out[4:], newCSTDecoder(), false)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !bytes.Equal(got, bitmap) {
+		t.Fatalf("roundtrip mismatch")
+	}
+}
+
+// TestCompressedGlobalShared constructs a multi-block bitmap where every
+// block has the exact same byte-skewed distribution. The picker should
+// emit one shared global table (rather than four identical own tables) and
+// reduce the embedded-table count from N to 1.
+func TestCompressedGlobalShared(t *testing.T) {
+	const sz = 128 << 10 // 4 huff0 blocks of 32 KiB
+	bitmap := make([]byte, sz)
+	rng := rand.New(rand.NewSource(22))
+	template := make([]byte, 32<<10)
+	for i := range template {
+		switch rng.Intn(4) {
+		case 0:
+			template[i] = 10
+		case 1:
+			template[i] = 20
+		case 2:
+			template[i] = 30
+		default:
+			template[i] = byte(40 + rng.Intn(8))
+		}
+	}
+	for blk := 0; blk < 4; blk++ {
+		copy(bitmap[blk*32<<10:], template)
+	}
+
+	cfg := NewSearchTableConfig().WithMatchLen(4)
+	cfg.baseTableSize = 20
+	var seen CompressedSearchStats
+	cfg = cfg.WithCompression(CompressedSearchForce(),
+		CompressedSearchStatsHook(func(s CompressedSearchStats) { seen = s }))
+	e := newCSTEncoder()
+	out, ok, err := appendSearchTableCompressedChunk(nil, &cfg, 0, bitmap, e)
+	if err != nil || !ok {
+		t.Fatalf("append err=%v ok=%v", err, ok)
+	}
+	if seen.BlocksGlobalTable < 2 {
+		t.Fatalf("expected ≥2 global users (identical-distribution blocks should share), got %d (own=%d raw=%d RLE=%d sparse=%d)",
+			seen.BlocksGlobalTable, seen.BlocksOwnTable, seen.BlocksRaw, seen.BlocksRLE, seen.BlocksSparse)
+	}
+	if seen.Tables > seen.BlocksGlobalTable {
+		t.Fatalf("expected ≤ BlocksGlobalTable tables emitted, got Tables=%d users=%d", seen.Tables, seen.BlocksGlobalTable)
+	}
+	_, _, got, err := parseSearchTableCompressed(out[4:], newCSTDecoder(), false)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !bytes.Equal(got, bitmap) {
+		t.Fatalf("roundtrip mismatch")
+	}
+}
+
+// TestCompressedConcurrentDecode hammers the per-sub-block worker goroutines
+// by parsing the same multi-block 0x46 chunk repeatedly with fresh decoders.
+// Intended to be run under `-race` to catch any cross-goroutine state bug in
+// the decompression workers or shared scratch buffers.
+func TestCompressedConcurrentDecode(t *testing.T) {
+	bitmap := makeBitmap(128<<10, 0.07, 99) // 4 huff0 blocks of 32 KiB
+	cfg := NewSearchTableConfig().WithMatchLen(4)
+	cfg.baseTableSize = 20
+	cfg = cfg.WithCompression(CompressedSearchForce())
+	e := newCSTEncoder()
+	out, ok, err := appendSearchTableCompressedChunk(nil, &cfg, 0, bitmap, e)
+	if err != nil || !ok {
+		t.Fatalf("encode: ok=%v err=%v", ok, err)
+	}
+	payload := out[4:]
+
+	const workers = 8
+	const iters = 32
+	errCh := make(chan error, workers)
+	for w := 0; w < workers; w++ {
+		go func() {
+			for i := 0; i < iters; i++ {
+				dec := newCSTDecoder()
+				_, _, got, err := parseSearchTableCompressed(payload, dec, false)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if !bytes.Equal(got, bitmap) {
+					errCh <- fmt.Errorf("mismatch")
+					return
+				}
+			}
+			errCh <- nil
+		}()
+	}
+	for w := 0; w < workers; w++ {
+		if err := <-errCh; err != nil {
+			t.Fatalf("worker: %v", err)
+		}
+	}
+}
+
+// TestCompressedReductionsInStats verifies the Reductions field is reported.
+func TestCompressedReductionsInStats(t *testing.T) {
+	bitmap := makeBitmap(8192, 0.10, 33)
+	var got CompressedSearchStats
+	cfg := NewSearchTableConfig().WithMatchLen(4).WithCompression(
+		CompressedSearchForce(),
+		CompressedSearchStatsHook(func(s CompressedSearchStats) { got = s }),
+	)
+	cfg.baseTableSize = 18
+	e := newCSTEncoder()
+	if _, ok, _ := appendSearchTableCompressedChunk(nil, &cfg, 2, bitmap, e); !ok {
+		t.Fatalf("force-emit failed")
+	}
+	if got.Reductions != 2 {
+		t.Fatalf("Reductions=%d, want 2", got.Reductions)
+	}
+}
+
+func TestCompressedSparseBitTableRoundtrip(t *testing.T) {
+	// Direct codec roundtrip for the sparse encoding.
+	cases := [][]byte{
+		make([]byte, 32),                     // all zero -> 0 bytes
+		bytes.Repeat([]byte{0xff}, 32),       // all one  -> 256 set bits, 256 bytes
+		{0x01, 0, 0, 0, 0, 0, 0, 0x80},       // 2 set bits, well separated
+		bytes.Repeat([]byte{0x00, 0x01}, 16), // every 16th bit
+	}
+	// One bit at position 8*1024-1.
+	{
+		b := make([]byte, 1024)
+		b[1023] = 0x80
+		cases = append(cases, b)
+	}
+	for i, in := range cases {
+		popcount := popcountBytes(in)
+		est := sparseBitTableEstimate(len(in), popcount)
+		enc := appendSparseBitTable(nil, in)
+		// Estimate is a tight upper bound on the actual encoded size.
+		if len(enc) > est {
+			t.Fatalf("case %d: actual=%d exceeds estimate=%d", i, len(enc), est)
+		}
+		dec := make([]byte, len(in))
+		if err := decodeSparseBitTable(dec, enc); err != nil {
+			t.Fatalf("case %d: decode: %v", i, err)
+		}
+		if !bytes.Equal(dec, in) {
+			t.Fatalf("case %d: roundtrip mismatch", i)
+		}
+	}
+}
+
+func TestCompressedSparseDispositionSelected(t *testing.T) {
+	// A bitmap with one set bit per 1024 bits: very sparse, sparse should win.
+	const sz = 4096
+	bitmap := make([]byte, sz)
+	for i := 0; i < sz; i += 128 {
+		bitmap[i] = 0x01
+	}
+	cfg := NewSearchTableConfig().WithMatchLen(4)
+	cfg.baseTableSize = 15 // 1<<(15-3) = 4096
+	var seen CompressedSearchStats
+	cfg = cfg.WithCompression(CompressedSearchForce(), CompressedSearchStatsHook(func(s CompressedSearchStats) { seen = s }))
+	e := newCSTEncoder()
+	out, ok, err := appendSearchTableCompressedChunk(nil, &cfg, 0, bitmap, e)
+	if err != nil || !ok {
+		t.Fatalf("append err=%v ok=%v", err, ok)
+	}
+	if seen.BlocksSparse == 0 {
+		t.Fatalf("expected sparse disposition, got own=%d global=%d raw=%d rle=%d sparse=%d",
+			seen.BlocksOwnTable, seen.BlocksGlobalTable, seen.BlocksRaw, seen.BlocksRLE, seen.BlocksSparse)
+	}
+	// Roundtrip.
+	dec := newCSTDecoder()
+	_, _, got, err := parseSearchTableCompressed(out[4:], dec, false)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !bytes.Equal(got, bitmap) {
+		t.Fatalf("bitmap mismatch")
+	}
+	if dec.lastBlocksSparse == 0 {
+		t.Fatalf("decoder did not record any sparse blocks")
 	}
 }
 
@@ -666,6 +892,67 @@ func BenchmarkCompressedSearchDecode(b *testing.B) {
 			b.ResetTimer()
 			for b.Loop() {
 				_, _, _, _ = parseSearchTableCompressed(payload, dec, false)
+			}
+		})
+	}
+}
+
+// BenchmarkCompressedSearchEncodeByPath drives the encoder on bitmaps tuned
+// to force each disposition family, so regressions in any one path show up
+// independently.
+func BenchmarkCompressedSearchEncodeByPath(b *testing.B) {
+	const sz = 64 << 10 // 2 huff0 blocks of 32 KiB
+	rng := rand.New(rand.NewSource(0xBE))
+
+	makeRLE := func() []byte { return make([]byte, sz) }
+	makeSparse := func() []byte {
+		bm := make([]byte, sz)
+		for i := 0; i < sz; i += 1024 {
+			bm[i] = 0x01
+		}
+		return bm
+	}
+	makeOwn := func() []byte {
+		// Skewed per-block (matchable by own table only): each block has its
+		// own set of frequent symbols.
+		bm := make([]byte, sz)
+		for i := 0; i < 32<<10; i++ {
+			bm[i] = byte(rng.Intn(4)) // block 0: symbols 0..3
+		}
+		for i := 32 << 10; i < sz; i++ {
+			bm[i] = byte(200 + rng.Intn(4)) // block 1: symbols 200..203
+		}
+		return bm
+	}
+	makeGlobal := func() []byte {
+		// Same skewed distribution in both blocks: global table wins.
+		bm := make([]byte, sz)
+		for i := range bm {
+			bm[i] = byte(rng.Intn(8))
+		}
+		return bm
+	}
+
+	cases := []struct {
+		name   string
+		bitmap []byte
+	}{
+		{"rle", makeRLE()},
+		{"sparse", makeSparse()},
+		{"own", makeOwn()},
+		{"global", makeGlobal()},
+	}
+
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			cfg := NewSearchTableConfig().WithMatchLen(4).WithCompression(CompressedSearchForce())
+			cfg.baseTableSize = 19
+			e := newCSTEncoder()
+			b.SetBytes(int64(sz))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				_, _, _ = appendSearchTableCompressedChunk(nil, &cfg, 0, c.bitmap, e)
 			}
 		})
 	}

--- a/search_compressed_test.go
+++ b/search_compressed_test.go
@@ -1,0 +1,711 @@
+package minlz
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// makeBitmap returns a `size`-byte bitmap with the given approximate population
+// fraction (0..1). Uses a deterministic RNG seeded with seed.
+func makeBitmap(size int, popFrac float64, seed int64) []byte {
+	rng := rand.New(rand.NewSource(seed))
+	b := make([]byte, size)
+	totalBits := size * 8
+	target := int(float64(totalBits) * popFrac)
+	for i := 0; i < target; i++ {
+		// Try to set a random unset bit. Retry on collisions; bounded retries
+		// keeps this test-only helper cheap even when popFrac is large.
+		for tries := 0; tries < 4; tries++ {
+			bit := rng.Intn(totalBits)
+			byteIdx := bit >> 3
+			mask := byte(1 << uint(bit&7))
+			if b[byteIdx]&mask == 0 {
+				b[byteIdx] |= mask
+				break
+			}
+		}
+	}
+	return b
+}
+
+func TestHuff0BlockSizePolicy(t *testing.T) {
+	cases := []struct {
+		bitmap   int
+		wantLog2 uint8
+		wantN    int
+	}{
+		{32, 5, 1},
+		{256, 8, 1},
+		{4096, 12, 1},
+		{8192, 13, 1},
+		{16384, 14, 1},
+		{32768, 15, 1},
+		{65536, 15, 2},
+		{131072, 15, 4},
+		{524288, 15, 16},
+		{1 << 20, 16, 16},
+	}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%d", c.bitmap), func(t *testing.T) {
+			gotL, gotN := huff0BlockSize(c.bitmap)
+			if gotL != c.wantLog2 || gotN != c.wantN {
+				t.Fatalf("huff0BlockSize(%d) = (%d, %d), want (%d, %d)", c.bitmap, gotL, gotN, c.wantLog2, c.wantN)
+			}
+			if gotN*(1<<gotL) != c.bitmap {
+				t.Fatalf("nBlocks*blockSize=%d != bitmap=%d", gotN*(1<<gotL), c.bitmap)
+			}
+		})
+	}
+}
+
+// chunkBitmapRoundtrip encodes a bitmap as 0x46 and parses it back.
+// Compression is forced so we always exercise the codec end-to-end.
+func chunkBitmapRoundtrip(t *testing.T, cfg SearchTableConfig, reductions uint8, bitmap []byte) {
+	t.Helper()
+	cfg = cfg.WithCompression(CompressedSearchForce())
+	e := newCSTEncoder()
+	out, ok, err := appendSearchTableCompressedChunk(nil, &cfg, reductions, bitmap, e)
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if !ok {
+		t.Fatalf("append refused (force should always emit)")
+	}
+	if out[0] != chunkTypeSearchTableCompressed {
+		t.Fatalf("expected chunk type 0x46, got 0x%x", out[0])
+	}
+	dec := newCSTDecoder()
+	cfgGot, redGot, tblGot, err := parseSearchTableCompressed(out[4:], dec, false)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfgGot.tableType != cfg.tableType || cfgGot.matchLen != cfg.matchLen || cfgGot.baseTableSize != cfg.baseTableSize {
+		t.Fatalf("config mismatch: got type=%d ml=%d ts=%d", cfgGot.tableType, cfgGot.matchLen, cfgGot.baseTableSize)
+	}
+	if redGot != reductions {
+		t.Fatalf("reductions: got %d want %d", redGot, reductions)
+	}
+	if !bytes.Equal(tblGot, bitmap) {
+		t.Fatalf("bitmap mismatch: got %d bytes, want %d", len(tblGot), len(bitmap))
+	}
+}
+
+func TestCompressedChunkRoundtrip(t *testing.T) {
+	// Bitmap sizes covering single-block (≤32KiB) and multi-block (>32KiB).
+	sizes := []int{256, 4096, 8192, 32 << 10, 64 << 10, 128 << 10}
+	pops := []struct {
+		name string
+		frac float64
+	}{
+		{"sparse", 0.05},
+		{"low", 0.15},
+		{"high", 0.85},
+		{"dense", 0.95},
+	}
+	cfgs := []struct {
+		name string
+		cfg  SearchTableConfig
+	}{
+		{"noPrefix", NewSearchTableConfig().WithMatchLen(4)},
+		{"bytePrefix", NewSearchTableConfig().WithMatchLen(4).WithBytePrefix('=', ':')},
+		{"longPrefix", NewSearchTableConfig().WithMatchLen(4).WithLongPrefix([]byte("id:"))},
+	}
+	for _, cc := range cfgs {
+		for _, sz := range sizes {
+			for _, p := range pops {
+				t.Run(fmt.Sprintf("%s/%d/%s", cc.name, sz, p.name), func(t *testing.T) {
+					bitmap := makeBitmap(sz, p.frac, 1)
+					// baseTableSize is set so 1 << (baseTableSize-3) == sz, i.e. log2(sz)+3.
+					// reductions = 0 to keep the bitmap at the chosen size.
+					var bts uint8
+					for i := uint8(8); i <= 23; i++ {
+						if 1<<(i-3) == sz {
+							bts = i
+							break
+						}
+					}
+					if bts == 0 {
+						t.Fatalf("no baseTableSize matches sz=%d", sz)
+					}
+					cfg := cc.cfg
+					cfg.baseTableSize = bts
+					chunkBitmapRoundtrip(t, cfg, 0, bitmap)
+				})
+			}
+		}
+	}
+}
+
+func TestCompressedPopcountBand(t *testing.T) {
+	// 50% population should hit the band and refuse 0x46.
+	bitmap := makeBitmap(4096, 0.50, 7)
+	cfg := NewSearchTableConfig().WithMatchLen(4).WithCompression(CompressedSearchSkipPct(5.0))
+	cfg.baseTableSize = 15
+	e := newCSTEncoder()
+	out, ok, err := appendSearchTableCompressedChunk(nil, &cfg, 0, bitmap, e)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if ok {
+		t.Fatalf("expected band rejection, got %d-byte 0x46 chunk", len(out))
+	}
+}
+
+func TestCompressedSkippedForTinyBitmap(t *testing.T) {
+	bitmap := make([]byte, 32)
+	bitmap[0] = 0x01
+	cfg := NewSearchTableConfig().WithMatchLen(4).WithCompression()
+	cfg.baseTableSize = 8
+	e := newCSTEncoder()
+	_, ok, _ := appendSearchTableCompressedChunk(nil, &cfg, 0, bitmap, e)
+	if ok {
+		t.Fatalf("expected size rejection for tiny bitmap")
+	}
+}
+
+func TestCompressedRLEAllZero(t *testing.T) {
+	// Multi-block all-zero bitmap → every huff0 block becomes RLE.
+	bitmap := make([]byte, 64<<10) // 2 blocks of 32KiB
+	cfg := NewSearchTableConfig().WithMatchLen(4)
+	cfg.baseTableSize = 19 // 1 << (19-3) = 65536
+	var seenStats CompressedSearchStats
+	cfg = cfg.WithCompression(CompressedSearchForce(), CompressedSearchStatsHook(func(s CompressedSearchStats) { seenStats = s }))
+	e := newCSTEncoder()
+	out, ok, err := appendSearchTableCompressedChunk(nil, &cfg, 0, bitmap, e)
+	if err != nil || !ok {
+		t.Fatalf("append err=%v ok=%v", err, ok)
+	}
+	// Validate roundtrip.
+	dec := newCSTDecoder()
+	_, _, got, err := parseSearchTableCompressed(out[4:], dec, false)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !bytes.Equal(got, bitmap) {
+		t.Fatalf("roundtrip mismatch")
+	}
+	// Every huff0 sub-block should be RLE.
+	if seenStats.BlocksRLE != seenStats.Huff0Blocks {
+		t.Fatalf("expected all %d blocks RLE, got own=%d global=%d raw=%d rle=%d",
+			seenStats.Huff0Blocks,
+			seenStats.BlocksOwnTable, seenStats.BlocksGlobalTable,
+			seenStats.BlocksRaw, seenStats.BlocksRLE)
+	}
+}
+
+func TestCompressedRLEAllOne(t *testing.T) {
+	bitmap := bytes.Repeat([]byte{0xff}, 32<<10)
+	cfg := NewSearchTableConfig().WithMatchLen(4)
+	cfg.baseTableSize = 18 // 1<<(18-3) = 32768
+	cfg = cfg.WithCompression(CompressedSearchForce())
+	e := newCSTEncoder()
+	out, ok, err := appendSearchTableCompressedChunk(nil, &cfg, 0, bitmap, e)
+	if err != nil || !ok {
+		t.Fatalf("append err=%v ok=%v", err, ok)
+	}
+	dec := newCSTDecoder()
+	_, _, got, err := parseSearchTableCompressed(out[4:], dec, false)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !bytes.Equal(got, bitmap) {
+		t.Fatalf("roundtrip mismatch")
+	}
+}
+
+func TestCompressedRejectMalformed(t *testing.T) {
+	// Build a valid chunk first.
+	bitmap := makeBitmap(4096, 0.10, 11)
+	cfg := NewSearchTableConfig().WithMatchLen(4)
+	cfg.baseTableSize = 15
+	cfg2 := cfg.WithCompression(CompressedSearchForce())
+	e := newCSTEncoder()
+	out, ok, err := appendSearchTableCompressedChunk(nil, &cfg2, 0, bitmap, e)
+	if err != nil || !ok {
+		t.Fatalf("setup: err=%v ok=%v", err, ok)
+	}
+	payload := out[4:]
+
+	t.Run("truncated", func(t *testing.T) {
+		for i := 0; i < len(payload); i += max(1, len(payload)/32) {
+			_, _, _, err := parseSearchTableCompressed(payload[:i], newCSTDecoder(), false)
+			if err == nil && i < len(payload) {
+				t.Fatalf("expected error for truncated len=%d", i)
+			}
+		}
+	})
+
+	t.Run("badCRC", func(t *testing.T) {
+		// CRC is at offset (3 + prefixSize() + 1) within the payload (after type/ml/baseSize/prefix/reductions).
+		off := 3 + cfg.prefixSize() + 1
+		corrupt := append([]byte(nil), payload...)
+		binary.LittleEndian.PutUint32(corrupt[off:], 0xdeadbeef)
+		_, _, _, err := parseSearchTableCompressed(corrupt, newCSTDecoder(), false)
+		if err == nil {
+			t.Fatalf("expected CRC error")
+		}
+	})
+
+	t.Run("badDisposition", func(t *testing.T) {
+		// Disposition for block 0 follows the table section. The simplest invalid
+		// is to mutate the byte directly after the table to a reserved value.
+		// We don't know the exact offset without parsing — flip every byte after
+		// the header looking for an out-of-range disposition that wasn't valid.
+		// Cheaper: rewrite the byte at position (len-1 or earlier) — pick a few.
+		corrupt := append([]byte(nil), payload...)
+		// Force every disposition byte to 200 by scanning common positions.
+		// This is a coarse but effective sanity check; we verify no panic.
+		for i := len(corrupt) / 2; i < len(corrupt); i++ {
+			corrupt[i] = 200
+		}
+		_, _, _, _ = parseSearchTableCompressed(corrupt, newCSTDecoder(), false)
+		// Expect either an error or possible (but rare) success on accidental
+		// alignment. The key invariant is no panic — runtime would catch one.
+	})
+
+	t.Run("badBaseTableSize", func(t *testing.T) {
+		corrupt := append([]byte(nil), payload...)
+		corrupt[2] = 0 // baseTableSize byte
+		_, _, _, err := parseSearchTableCompressed(corrupt, newCSTDecoder(), false)
+		if err == nil {
+			t.Fatalf("expected error for invalid baseTableSize")
+		}
+	})
+}
+
+func TestCompressedWriterRoundtrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(123))
+	// Mix of compressible and skewed regions.
+	data := make([]byte, 200<<10)
+	for i := range data {
+		switch {
+		case i%17 == 0:
+			data[i] = 'A' + byte(i%26)
+		case i%7 == 0:
+			data[i] = byte(rng.Intn(8))
+		default:
+			data[i] = byte(rng.Intn(256))
+		}
+	}
+	// Embed needles for searcher tests.
+	copy(data[1024:], []byte("MAGIC_NEEDLE"))
+	copy(data[50<<10:], []byte("MAGIC_NEEDLE"))
+
+	for _, conc := range []int{1, 4} {
+		t.Run(fmt.Sprintf("conc=%d", conc), func(t *testing.T) {
+			cfg := NewSearchTableConfig().WithMatchLen(4).WithCompression(CompressedSearchForce())
+			var buf bytes.Buffer
+			w := NewWriter(&buf,
+				WriterSearchTable(cfg),
+				WriterBlockSize(64<<10),
+				WriterConcurrency(conc),
+			)
+			if _, err := w.Write(data); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
+			// Confirm 0x46 chunks are present in the stream.
+			found46 := bytes.IndexByte(buf.Bytes(), chunkTypeSearchTableCompressed)
+			if found46 < 0 {
+				t.Fatalf("expected at least one 0x46 chunk in stream")
+			}
+			// Decode the stream.
+			decoded, err := io.ReadAll(NewReader(bytes.NewReader(buf.Bytes())))
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if !bytes.Equal(decoded, data) {
+				t.Fatalf("data mismatch (len=%d, want=%d)", len(decoded), len(data))
+			}
+		})
+	}
+}
+
+// TestCompressedSearcherStats verifies the compressed-table fields in
+// SearchStats are populated correctly when 0x46 chunks are present.
+func TestCompressedSearcherStatsFields(t *testing.T) {
+	rng := rand.New(rand.NewSource(321))
+	data := make([]byte, 200<<10)
+	for i := range data {
+		data[i] = byte(rng.Intn(8)) // skewed so 0x46 is profitable
+	}
+	cfg := NewSearchTableConfig().WithMatchLen(4).WithCompression(CompressedSearchForce())
+	var buf bytes.Buffer
+	w := NewWriter(&buf,
+		WriterSearchTable(cfg),
+		WriterBlockSize(64<<10),
+		WriterConcurrency(1),
+	)
+	if _, err := w.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	s := NewBlockSearcher(bytes.NewReader(buf.Bytes()), BlockSearchCollectStats())
+	if err := s.Search([]byte("THIS_PROBABLY_DOES_NOT_EXIST_IN_DATA"), func(r SearchResult) error { return nil }); err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	stats := s.Stats()
+	if stats.TablesCompressed == 0 {
+		t.Fatalf("expected TablesCompressed > 0, got %d (TablesPresent=%d)", stats.TablesCompressed, stats.TablesPresent)
+	}
+	if stats.TablesCompressedBytes == 0 {
+		t.Fatalf("expected TablesCompressedBytes > 0")
+	}
+	if stats.TableBitmapBytes == 0 {
+		t.Fatalf("expected TableBitmapBytes > 0")
+	}
+	if stats.TablesCompressed > stats.TablesPresent {
+		t.Fatalf("compressed > present: %d > %d", stats.TablesCompressed, stats.TablesPresent)
+	}
+	if stats.TablesCompressedBytes > stats.TablesBytes {
+		t.Fatalf("compressed bytes > total bytes")
+	}
+}
+
+func TestCompressedSearcherRoundtrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(456))
+	data := make([]byte, 256<<10)
+	for i := range data {
+		data[i] = byte(rng.Intn(64))
+	}
+	needle := []byte("XYZNEEDLEZYX")
+	// Insert needles at known offsets.
+	offsets := []int{100, 1024, 70 << 10, 150 << 10}
+	for _, o := range offsets {
+		copy(data[o:], needle)
+	}
+
+	cfg := NewSearchTableConfig().WithMatchLen(4).WithCompression(CompressedSearchForce())
+	var buf bytes.Buffer
+	w := NewWriter(&buf,
+		WriterSearchTable(cfg),
+		WriterBlockSize(64<<10),
+		WriterConcurrency(2),
+	)
+	if _, err := w.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	s := NewBlockSearcher(bytes.NewReader(buf.Bytes()))
+	var found []int64
+	err := s.Search(needle, func(r SearchResult) error {
+		found = append(found, r.StreamOffset)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(found) != len(offsets) {
+		t.Fatalf("found %d matches, want %d (offsets=%v)", len(found), len(offsets), found)
+	}
+	for i, o := range offsets {
+		if found[i] != int64(o) {
+			t.Fatalf("match %d offset: got %d want %d", i, found[i], o)
+		}
+	}
+}
+
+// TestCompressedFallbackTo45 confirms that without CompressedSearchForce, the
+// encoder emits 0x45 when 0x46 wouldn't be smaller.
+func TestCompressedFallbackTo45(t *testing.T) {
+	// Build a bitmap with popcount well outside the band but very high entropy
+	// at the byte level — Compress4X may either compress poorly or refuse,
+	// either way the 0x46 path should not beat 0x45.
+	bitmap := makeBitmap(4096, 0.50, 17) // band rejects this too — both effects combine
+	cfg := NewSearchTableConfig().WithMatchLen(4).WithCompression()
+	cfg.baseTableSize = 15
+	e := newCSTEncoder()
+	out, ok, _ := appendSearchTableCompressedChunk(nil, &cfg, 0, bitmap, e)
+	if ok {
+		t.Fatalf("expected fallback, but 0x46 was emitted (%d bytes)", len(out))
+	}
+}
+
+// TestCompressedStatsHook validates the stats hook reports plausible values.
+func TestCompressedStatsHook(t *testing.T) {
+	bitmap := makeBitmap(8192, 0.10, 33)
+	var got CompressedSearchStats
+	cfg := NewSearchTableConfig().WithMatchLen(4).WithCompression(
+		CompressedSearchForce(),
+		CompressedSearchStatsHook(func(s CompressedSearchStats) { got = s }),
+	)
+	cfg.baseTableSize = 16
+	e := newCSTEncoder()
+	if _, ok, _ := appendSearchTableCompressedChunk(nil, &cfg, 0, bitmap, e); !ok {
+		t.Fatalf("expected force-emitted 0x46")
+	}
+	if got.BitmapBytes != 8192 {
+		t.Fatalf("BitmapBytes=%d", got.BitmapBytes)
+	}
+	if got.Huff0Blocks != 1 || got.Huff0BlockSize != 8192 {
+		t.Fatalf("Huff0Blocks=%d size=%d", got.Huff0Blocks, got.Huff0BlockSize)
+	}
+	totalBlocks := got.BlocksOwnTable + got.BlocksGlobalTable + got.BlocksRaw + got.BlocksRLE
+	if totalBlocks != got.Huff0Blocks {
+		t.Fatalf("sub-block counts %d do not sum to Huff0Blocks %d", totalBlocks, got.Huff0Blocks)
+	}
+	if got.Chunk0x45Size == 0 || got.Chunk0x46Size == 0 || !got.Emitted0x46 {
+		t.Fatalf("size stats unexpected: %+v", got)
+	}
+}
+
+// TestCompressedReductionInteraction confirms encode/decode roundtrips when
+// the bitmap has been reduced (its size is smaller than 1<<(baseTableSize-3)).
+func TestCompressedReductionInteraction(t *testing.T) {
+	// baseTableSize=18 → unreduced size = 1<<15 = 32768. With reductions=2,
+	// effective size = 1<<13 = 8192.
+	bitmap := makeBitmap(8192, 0.10, 99)
+	cfg := NewSearchTableConfig().WithMatchLen(4).WithCompression(CompressedSearchForce())
+	cfg.baseTableSize = 18
+	chunkBitmapRoundtrip(t, cfg, 2, bitmap)
+}
+
+// TestCompressedSmallInputRoundtrip reproduces a fuzz failure: a sub-block-size
+// input with compression enabled must still decode cleanly.
+func TestCompressedSmallInputRoundtrip(t *testing.T) {
+	data := []byte("b9872 fox jumps ove1 the lazy2899C192aC920810070000100011010101129 fox jumps ov1 the lazy000")
+	cfg := NewSearchTableConfig().WithMatchLen(4).WithCompression(CompressedSearchForce())
+	var buf bytes.Buffer
+	w := NewWriter(&buf,
+		WriterSearchTable(cfg),
+		WriterBlockSize(minBlockSize),
+		WriterConcurrency(1),
+	)
+	if _, err := w.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	t.Logf("stream length: %d bytes", buf.Len())
+	t.Logf("stream hex: %x", buf.Bytes())
+	decoded, err := io.ReadAll(NewReader(bytes.NewReader(buf.Bytes())))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !bytes.Equal(decoded, data) {
+		t.Fatalf("mismatch: got %d bytes, want %d", len(decoded), len(data))
+	}
+}
+
+// FuzzCompressedSearchRoundtrip drives Writer with compression, asserts the
+// Reader fully decodes the stream, AND asserts that BlockSearcher finds every
+// occurrence of the supplied pattern via the 0x46 chunks.
+func FuzzCompressedSearchRoundtrip(f *testing.F) {
+	f.Add([]byte("the quick brown fox jumps over the lazy dog. this string is repeated. the quick brown fox jumps over the lazy dog."), []byte("fox"), 4, false)
+	f.Add(bytes.Repeat([]byte("abcdefgh"), 1024), []byte("abcd"), 6, false)
+	f.Add([]byte("key1=value1&key2=value2&key3=value3"), []byte("value"), 4, true)
+	f.Fuzz(func(t *testing.T, data, pattern []byte, matchLen int, usePrefix bool) {
+		if len(data) < 64 || len(pattern) < 1 || len(pattern) > 100 {
+			return
+		}
+		if matchLen < 1 || matchLen > 8 {
+			return
+		}
+		cfg := NewSearchTableConfig().WithMatchLen(matchLen).WithCompression(CompressedSearchForce())
+		if usePrefix && pattern[0] != 0 {
+			cfg = cfg.WithBytePrefix(pattern[0])
+		}
+		var buf bytes.Buffer
+		w := NewWriter(&buf,
+			WriterSearchTable(cfg),
+			WriterBlockSize(minBlockSize),
+			WriterConcurrency(1),
+		)
+		if _, err := w.Write(data); err != nil {
+			return
+		}
+		if err := w.Close(); err != nil {
+			return
+		}
+
+		// 1) Reader transparently skips the 0x46 chunks; output must equal input.
+		decoded, err := io.ReadAll(NewReader(bytes.NewReader(buf.Bytes())))
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if !bytes.Equal(decoded, data) {
+			t.Fatalf("roundtrip mismatch len=%d want=%d", len(decoded), len(data))
+		}
+
+		// 2) Compute reference matches (every occurrence of pattern in data;
+		// for prefix tables, only occurrences preceded by the prefix byte).
+		var expected []int64
+		if usePrefix {
+			pfx := pattern[0]
+			needle := append([]byte{pfx}, pattern...)
+			off := 0
+			for {
+				idx := bytes.Index(data[off:], needle)
+				if idx < 0 {
+					break
+				}
+				expected = append(expected, int64(off+idx+1))
+				off += idx + 1
+			}
+		} else {
+			off := 0
+			for {
+				idx := bytes.Index(data[off:], pattern)
+				if idx < 0 {
+					break
+				}
+				expected = append(expected, int64(off+idx))
+				off += idx + 1
+			}
+		}
+		if len(expected) == 0 {
+			return
+		}
+
+		// 3) Drive BlockSearcher — it must find every expected offset by
+		// parsing the 0x46 chunks emitted above.
+		searcher := NewBlockSearcher(bytes.NewReader(buf.Bytes()), BlockSearchCollectStats())
+		foundSet := make(map[int64]bool, len(expected))
+		if err := searcher.Search(pattern, func(r SearchResult) error {
+			foundSet[r.StreamOffset] = true
+			return nil
+		}); err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		// At least one 0x46 chunk must have been parsed for this test to be
+		// meaningful (otherwise we'd be exercising 0x45 fallback only).
+		stats := searcher.Stats()
+		if stats.TablesCompressed == 0 {
+			t.Skipf("no 0x46 chunks emitted (matchLen=%d usePrefix=%v len=%d)", matchLen, usePrefix, len(data))
+		}
+		for _, e := range expected {
+			if !foundSet[e] {
+				t.Fatalf("expected match at offset %d not found (prefix=%v, expected=%d found=%d). "+
+					"blocks: total=%d skipped=%d searched=%d compressed=%d",
+					e, usePrefix, len(expected), len(foundSet),
+					stats.BlocksTotal, stats.BlocksSkipped, stats.BlocksSearched, stats.TablesCompressed)
+			}
+		}
+	})
+}
+
+// FuzzDecodeCompressedSearchChunk feeds arbitrary bytes to the 0x46 parser.
+// The parser must not panic; any output is acceptable.
+func FuzzDecodeCompressedSearchChunk(f *testing.F) {
+	// Add some valid seeds.
+	bitmap := makeBitmap(256, 0.05, 1)
+	cfg := NewSearchTableConfig().WithMatchLen(4).WithCompression(CompressedSearchForce())
+	cfg.baseTableSize = 11
+	e := newCSTEncoder()
+	out, ok, _ := appendSearchTableCompressedChunk(nil, &cfg, 0, bitmap, e)
+	if ok {
+		f.Add(out[4:])
+	}
+	f.Add([]byte{})
+	f.Add([]byte{0x01})
+	f.Fuzz(func(t *testing.T, b []byte) {
+		_, _, _, _ = parseSearchTableCompressed(b, newCSTDecoder(), false)
+	})
+}
+
+// Benchmarks
+
+func BenchmarkCompressedSearchEncode(b *testing.B) {
+	for _, sz := range []int{4096, 8192, 64 << 10, 128 << 10, 512 << 10, 1 << 20} {
+		b.Run(fmt.Sprintf("%d", sz), func(b *testing.B) {
+			bitmap := makeBitmap(sz, 0.10, 42)
+			cfg := NewSearchTableConfig().WithMatchLen(4).WithCompression(CompressedSearchForce())
+			// Choose baseTableSize so 1<<(bts-3) == sz.
+			for i := uint8(8); i <= 23; i++ {
+				if 1<<(i-3) == sz {
+					cfg.baseTableSize = i
+					break
+				}
+			}
+			e := newCSTEncoder()
+			b.SetBytes(int64(sz))
+			b.ResetTimer()
+			b.ReportAllocs()
+			var dst []byte
+			for b.Loop() {
+				dst, _, _ = appendSearchTableCompressedChunk(dst[:0], &cfg, 0, bitmap, e)
+			}
+		})
+	}
+}
+
+func BenchmarkCompressedSearchDecode(b *testing.B) {
+	for _, sz := range []int{4096, 8192, 64 << 10, 128 << 10, 512 << 10, 1 << 20} {
+		b.Run(fmt.Sprintf("%d", sz), func(b *testing.B) {
+			bitmap := makeBitmap(sz, 0.10, 42)
+			cfg := NewSearchTableConfig().WithMatchLen(4).WithCompression(CompressedSearchForce())
+			for i := uint8(8); i <= 23; i++ {
+				if 1<<(i-3) == sz {
+					cfg.baseTableSize = i
+					break
+				}
+			}
+			e := newCSTEncoder()
+			out, ok, _ := appendSearchTableCompressedChunk(nil, &cfg, 0, bitmap, e)
+			if !ok {
+				b.Fatal("force-emit failed")
+			}
+			payload := out[4:]
+			dec := newCSTDecoder()
+			b.SetBytes(int64(sz))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				_, _, _, _ = parseSearchTableCompressed(payload, dec, false)
+			}
+		})
+	}
+}
+
+// Quick smoke benchmark covering the Writer→Reader path with compression on
+// vs off so the developer can eyeball wire-size differences.
+func BenchmarkCompressedSearchVsUncompressed(b *testing.B) {
+	rng := rand.New(rand.NewSource(7))
+	data := make([]byte, 256<<10)
+	for i := range data {
+		data[i] = byte(rng.Intn(16)) // skewed → good for compression
+	}
+	run := func(b *testing.B, useCompression bool) {
+		cfg := NewSearchTableConfig().WithMatchLen(4)
+		if useCompression {
+			cfg = cfg.WithCompression()
+		}
+		b.SetBytes(int64(len(data)))
+		b.ReportAllocs()
+		var lastLen int
+		for b.Loop() {
+			var buf bytes.Buffer
+			buf.Grow(len(data))
+			w := NewWriter(&buf,
+				WriterUncompressed(),
+				WriterSearchTable(cfg),
+				WriterBlockSize(64<<10),
+				WriterConcurrency(1),
+			)
+			_, _ = w.Write(data)
+			_ = w.Close()
+			lastLen = buf.Len()
+		}
+		// Use lastLen so the compiler doesn't elide the buffer.
+		_ = lastLen
+	}
+	b.Run("uncompressed", func(b *testing.B) { run(b, false) })
+	b.Run("compressed", func(b *testing.B) { run(b, true) })
+}
+
+// Suppress unused-import warning when -tags ... drops the strings import.
+var _ = strings.HasPrefix

--- a/search_examples_test.go
+++ b/search_examples_test.go
@@ -147,4 +147,5 @@ func ExampleSearchStats_Fprint() {
 	// Table bits/byte: 0.0430, log2: 8.0, avg reductions: 5.0
 	// Table total: 88 bytes, avg 44 bytes/table, 0.54% of 16384 uncompressed
 	// Table population: avg 2.7%, min 1.6%, max 3.9%
+	// Table types: 2 uncompressed (0x45), 0 compressed (0x46)
 }

--- a/search_index.go
+++ b/search_index.go
@@ -859,8 +859,8 @@ func buildTablePrefixLong(table []byte, data []byte, nPositions int, tableSize, 
 	safeEnd := max(0, len(data)-7)
 	mainEnd := min(n, safeEnd)
 
-	switch {
-	case pl == 1:
+	switch pl {
+	case 1:
 		// Single byte prefix - similar to mask but with one value.
 		p := prefix[0]
 		switch matchLen {

--- a/search_reader.go
+++ b/search_reader.go
@@ -41,10 +41,20 @@ type SearchStats struct {
 	TableBitmapBytes      int64 // Total uncompressed bitmap bytes across 0x46 chunks
 
 	// huff0 sub-block breakdown for the 0x46 chunks above.
-	Huff0BlocksTotal int // Sum of huff0 sub-blocks across all 0x46 chunks
-	Huff0BlocksRaw   int // Sub-blocks with disposition = raw
-	Huff0BlocksRLE   int // Sub-blocks with disposition = RLE
-	Huff0TablesSum   int // Sum of distinct huff0 tables emitted across all 0x46 chunks
+	Huff0BlocksTotal  int // Sum of huff0 sub-blocks across all 0x46 chunks
+	Huff0BlocksRaw    int // Sub-blocks with disposition = raw
+	Huff0BlocksRLE    int // Sub-blocks with disposition = RLE
+	Huff0BlocksSparse int // Sub-blocks with disposition = sparse bit table
+	Huff0TablesSum    int // Sum of distinct huff0 tables emitted across all 0x46 chunks
+
+	// Wire-byte breakdown of 0x46 sub-block payloads (excludes the disposition
+	// byte itself; for tabled blocks includes the uvarint length prefix and
+	// compressed data, but NOT the table header — that's tracked separately).
+	Huff0BytesTabled       int64
+	Huff0BytesRaw          int64
+	Huff0BytesRLE          int64
+	Huff0BytesSparse       int64
+	Huff0BytesTableHeaders int64 // bytes consumed by serialized huff0 tables
 }
 
 // Fprint writes a human-readable summary of the search stats to w.
@@ -75,6 +85,11 @@ func (st SearchStats) Fprint(w io.Writer) {
 		fmt.Fprintln(w)
 		avg := st.TablePopSum / float64(st.TablesPresent)
 		fmt.Fprintf(w, "Table population: avg %.1f%%, min %.1f%%, max %.1f%%\n", avg, st.TablePopMin, st.TablePopMax)
+		uncompressed := st.TablesPresent - st.TablesCompressed
+		if uncompressed > 0 || st.TablesCompressed > 0 {
+			fmt.Fprintf(w, "Table types: %d uncompressed (0x45), %d compressed (0x46)\n",
+				uncompressed, st.TablesCompressed)
+		}
 		if st.TablesCompressed > 0 {
 			ratio := 100.0
 			if st.TableBitmapBytes > 0 {
@@ -83,13 +98,15 @@ func (st SearchStats) Fprint(w io.Writer) {
 			fmt.Fprintf(w, "Compressed tables: %d (%.1f%% of total), %d wire bytes, %d uncompressed bitmap bytes (%.2f%% ratio)\n",
 				st.TablesCompressed, pct(st.TablesCompressed, st.TablesPresent),
 				st.TablesCompressedBytes, st.TableBitmapBytes, ratio)
-			tabled := st.Huff0BlocksTotal - st.Huff0BlocksRaw - st.Huff0BlocksRLE
+			tabled := st.Huff0BlocksTotal - st.Huff0BlocksRaw - st.Huff0BlocksRLE - st.Huff0BlocksSparse
 			share := 0.0
 			if tabled > 0 {
 				share = float64(st.Huff0TablesSum) / float64(tabled)
 			}
-			fmt.Fprintf(w, "huff0 sub-blocks: %d total (%d tabled, %d raw, %d RLE); %d tables emitted (share=%.2f tables/tabled-block)\n",
-				st.Huff0BlocksTotal, tabled, st.Huff0BlocksRaw, st.Huff0BlocksRLE, st.Huff0TablesSum, share)
+			fmt.Fprintf(w, "huff0 sub-blocks: %d total (%d tabled, %d raw, %d RLE, %d sparse); %d tables emitted (share=%.2f tables/tabled-block)\n",
+				st.Huff0BlocksTotal, tabled, st.Huff0BlocksRaw, st.Huff0BlocksRLE, st.Huff0BlocksSparse, st.Huff0TablesSum, share)
+			fmt.Fprintf(w, "  payload bytes: tabled=%d raw=%d RLE=%d sparse=%d; table-header bytes=%d\n",
+				st.Huff0BytesTabled, st.Huff0BytesRaw, st.Huff0BytesRLE, st.Huff0BytesSparse, st.Huff0BytesTableHeaders)
 		}
 	}
 }
@@ -453,7 +470,13 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 				s.stats.Huff0BlocksTotal += s.cstDec.lastBlocks
 				s.stats.Huff0BlocksRaw += s.cstDec.lastBlocksRaw
 				s.stats.Huff0BlocksRLE += s.cstDec.lastBlocksRLE
+				s.stats.Huff0BlocksSparse += s.cstDec.lastBlocksSparse
 				s.stats.Huff0TablesSum += s.cstDec.lastTables
+				s.stats.Huff0BytesTabled += int64(s.cstDec.lastBytesTabled)
+				s.stats.Huff0BytesRaw += int64(s.cstDec.lastBytesRaw)
+				s.stats.Huff0BytesRLE += int64(s.cstDec.lastBytesRLE)
+				s.stats.Huff0BytesSparse += int64(s.cstDec.lastBytesSparse)
+				s.stats.Huff0BytesTableHeaders += int64(s.cstDec.lastBytesTableHeader)
 				s.stats.TableBitsSum += int(cfg.baseTableSize - reductions)
 				s.stats.TableReductionsSum += int(reductions)
 				setBits := 0

--- a/search_reader.go
+++ b/search_reader.go
@@ -240,6 +240,7 @@ type BlockSearcher struct {
 	deferred     *deferredMatch // pending ErrSearchForward re-dispatch
 	pending      *pendingBlock  // block deferred pending next table check
 	cstDec       *cstDecoder    // lazy decoder state for 0x46 chunks
+	infoCallback func(SearchTableConfig)
 	maxBlock     int
 	readHeader   bool
 	ignoreCRC    bool
@@ -258,6 +259,17 @@ type BlockSearchOption func(*BlockSearcher) error
 func BlockSearchBailOnMissing() BlockSearchOption {
 	return func(s *BlockSearcher) error {
 		s.bail = true
+		return nil
+	}
+}
+
+// BlockSearchInfoCallback installs fn to be invoked when a Search Table Info
+// chunk (0x44) is parsed from the stream. The callback receives the parsed
+// SearchTableConfig and is intended for logging / introspection. The callback
+// must not retain references to mutable state inside the config.
+func BlockSearchInfoCallback(fn func(SearchTableConfig)) BlockSearchOption {
+	return func(s *BlockSearcher) error {
+		s.infoCallback = fn
 		return nil
 	}
 }
@@ -389,6 +401,9 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 				return err
 			}
 			s.streamInfo = &cfg
+			if s.infoCallback != nil {
+				s.infoCallback(cfg)
+			}
 			// Preallocate the compressed-table bitmap buffer to the stream's
 			// maximum (un-reduced) bitmap size so subsequent 0x46 parses don't
 			// grow it.

--- a/search_reader.go
+++ b/search_reader.go
@@ -20,8 +20,8 @@ type SearchStats struct {
 	BlocksSearched        int     // Blocks decoded and passed to callback
 	CompBytesSkipped      int64   // Compressed bytes skipped
 	UncompBytesSearched   int64   // Uncompressed bytes decoded and searched
-	TablesPresent         int     // Number of 0x45 search table chunks seen
-	TablesBytes           int64   // Total bytes of search table chunks
+	TablesPresent         int     // Number of 0x45 + 0x46 search table chunks seen
+	TablesBytes           int64   // Total wire bytes of search table chunks (0x45 + 0x46)
 	TablesMissing         int     // Data blocks without a preceding search table
 	TablesUnusable        int     // Tables present but incompatible with query
 	TableBitsSum          int     // Sum of effective table bits (for avg: TableBitsSum/TablesPresent)
@@ -33,6 +33,18 @@ type SearchStats struct {
 	TablePopMax           float64 // Max population % across tables seen
 	TablePopSum           float64 // Sum of population % (for computing average)
 	UncompressedSize      int64   // Total uncompressed bytes in stream
+
+	// Compressed search-table (chunk type 0x46) breakdown. These count a
+	// subset of TablesPresent / TablesBytes.
+	TablesCompressed      int   // Number of 0x46 chunks seen
+	TablesCompressedBytes int64 // Total wire bytes of 0x46 chunks (subset of TablesBytes)
+	TableBitmapBytes      int64 // Total uncompressed bitmap bytes across 0x46 chunks
+
+	// huff0 sub-block breakdown for the 0x46 chunks above.
+	Huff0BlocksTotal int // Sum of huff0 sub-blocks across all 0x46 chunks
+	Huff0BlocksRaw   int // Sub-blocks with disposition = raw
+	Huff0BlocksRLE   int // Sub-blocks with disposition = RLE
+	Huff0TablesSum   int // Sum of distinct huff0 tables emitted across all 0x46 chunks
 }
 
 // Fprint writes a human-readable summary of the search stats to w.
@@ -63,6 +75,22 @@ func (st SearchStats) Fprint(w io.Writer) {
 		fmt.Fprintln(w)
 		avg := st.TablePopSum / float64(st.TablesPresent)
 		fmt.Fprintf(w, "Table population: avg %.1f%%, min %.1f%%, max %.1f%%\n", avg, st.TablePopMin, st.TablePopMax)
+		if st.TablesCompressed > 0 {
+			ratio := 100.0
+			if st.TableBitmapBytes > 0 {
+				ratio = float64(st.TablesCompressedBytes) * 100 / float64(st.TableBitmapBytes)
+			}
+			fmt.Fprintf(w, "Compressed tables: %d (%.1f%% of total), %d wire bytes, %d uncompressed bitmap bytes (%.2f%% ratio)\n",
+				st.TablesCompressed, pct(st.TablesCompressed, st.TablesPresent),
+				st.TablesCompressedBytes, st.TableBitmapBytes, ratio)
+			tabled := st.Huff0BlocksTotal - st.Huff0BlocksRaw - st.Huff0BlocksRLE
+			share := 0.0
+			if tabled > 0 {
+				share = float64(st.Huff0TablesSum) / float64(tabled)
+			}
+			fmt.Fprintf(w, "huff0 sub-blocks: %d total (%d tabled, %d raw, %d RLE); %d tables emitted (share=%.2f tables/tabled-block)\n",
+				st.Huff0BlocksTotal, tabled, st.Huff0BlocksRaw, st.Huff0BlocksRLE, st.Huff0TablesSum, share)
+		}
 	}
 }
 
@@ -194,6 +222,7 @@ type BlockSearcher struct {
 	prevLazy     *lazyBlock     // compressed previous block for lazy PrevBlock(); nil if decoded
 	deferred     *deferredMatch // pending ErrSearchForward re-dispatch
 	pending      *pendingBlock  // block deferred pending next table check
+	cstDec       *cstDecoder    // lazy decoder state for 0x46 chunks
 	maxBlock     int
 	readHeader   bool
 	ignoreCRC    bool
@@ -343,6 +372,18 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 				return err
 			}
 			s.streamInfo = &cfg
+			// Preallocate the compressed-table bitmap buffer to the stream's
+			// maximum (un-reduced) bitmap size so subsequent 0x46 parses don't
+			// grow it.
+			if cfg.baseTableSize >= 3 {
+				maxBitmap := 1 << (cfg.baseTableSize - 3)
+				if s.cstDec == nil {
+					s.cstDec = newCSTDecoder()
+				}
+				if cap(s.cstDec.bitmapBuf) < maxBitmap {
+					s.cstDec.bitmapBuf = make([]byte, maxBitmap)
+				}
+			}
 			continue
 
 		case chunkTypeSearchTable:
@@ -366,6 +407,53 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 			if s.collectStats {
 				s.stats.TablesPresent++
 				s.stats.TablesBytes += int64(chunkLen + 4) // +4 for chunk header
+				s.stats.TableBitsSum += int(cfg.baseTableSize - reductions)
+				s.stats.TableReductionsSum += int(reductions)
+				setBits := 0
+				for _, b := range table {
+					setBits += bits.OnesCount8(b)
+				}
+				pop := float64(setBits) * 100 / float64(len(table)*8)
+				s.stats.TablePopSum += pop
+				if s.stats.TablesPresent == 1 || pop < s.stats.TablePopMin {
+					s.stats.TablePopMin = pop
+				}
+				if pop > s.stats.TablePopMax {
+					s.stats.TablePopMax = pop
+				}
+			}
+			continue
+
+		case chunkTypeSearchTableCompressed:
+			s.ensureBuf(chunkLen)
+			if !s.readFull(s.buf[:chunkLen]) {
+				return s.err
+			}
+			if s.cstDec == nil {
+				s.cstDec = newCSTDecoder()
+			}
+			cfg, reductions, table, err := parseSearchTableCompressed(s.buf[:chunkLen], s.cstDec, s.ignoreCRC)
+			if err != nil {
+				return err
+			}
+			s.blockInfo = cfg
+			s.blockReductions = reductions
+			s.blockTable = table
+			if s.pending != nil {
+				if err := s.resolvePending(pattern, fn); err != nil {
+					return err
+				}
+			}
+			if s.collectStats {
+				s.stats.TablesPresent++
+				s.stats.TablesBytes += int64(chunkLen + 4)
+				s.stats.TablesCompressed++
+				s.stats.TablesCompressedBytes += int64(chunkLen + 4)
+				s.stats.TableBitmapBytes += int64(len(table))
+				s.stats.Huff0BlocksTotal += s.cstDec.lastBlocks
+				s.stats.Huff0BlocksRaw += s.cstDec.lastBlocksRaw
+				s.stats.Huff0BlocksRLE += s.cstDec.lastBlocksRLE
+				s.stats.Huff0TablesSum += s.cstDec.lastTables
 				s.stats.TableBitsSum += int(cfg.baseTableSize - reductions)
 				s.stats.TableReductionsSum += int(reductions)
 				setBits := 0

--- a/search_table.go
+++ b/search_table.go
@@ -41,6 +41,7 @@ type SearchTableConfig struct {
 	longPrefix       []byte
 	maxPopPct        int
 	maxReducedPopPct int
+	compression      *compressedOpts // nil = emit 0x45 only
 }
 
 // NewSearchTableConfig creates a search table config.
@@ -108,6 +109,25 @@ func (c SearchTableConfig) WithMaxPopulation(pct int) SearchTableConfig {
 // reduced table. Reductions stop before exceeding this threshold.
 func (c SearchTableConfig) WithMaxReducedPopulation(pct int) SearchTableConfig {
 	c.maxReducedPopPct = pct
+	return c
+}
+
+// WithCompression enables huff0 compression of per-block search tables.
+// This will reduce search index size on high quality search indexes,
+// with low population count.
+// Search Indexes that can only be marginally compressed are stored uncompressed.
+//
+// With no options, defaults are: 10.0% popcount band, no stats hook,
+// non-forced (emit compressed only when smaller).
+func (c SearchTableConfig) WithCompression(opts ...CompressedSearchOption) SearchTableConfig {
+	co := &compressedOpts{
+		enabled:         true,
+		skipPctTimes100: cstDefaultSkipPctTimes100,
+	}
+	for _, o := range opts {
+		o(co)
+	}
+	c.compression = co
 	return c
 }
 

--- a/search_table.go
+++ b/search_table.go
@@ -44,6 +44,42 @@ type SearchTableConfig struct {
 	compression      *compressedOpts // nil = emit 0x45 only
 }
 
+// String returns a one-line, human-readable summary of the search table
+// configuration. Useful for logging the contents of an 0x44 chunk.
+func (c SearchTableConfig) String() string {
+	var prefix string
+	switch c.tableType {
+	case searchTableTypeNoPrefix:
+		prefix = "no-prefix"
+	case searchTableTypeBytePrefix:
+		// Compact the prefixBytes array — duplicates are encoder-internal padding.
+		seen := make(map[byte]struct{}, 8)
+		var unique []byte
+		for _, b := range c.prefixBytes {
+			if _, ok := seen[b]; ok {
+				continue
+			}
+			seen[b] = struct{}{}
+			unique = append(unique, b)
+		}
+		prefix = fmt.Sprintf("byte-prefix=%q", string(unique))
+	case searchTableTypeMaskPrefix:
+		n := 0
+		for i := range 256 {
+			if c.prefixMask[i>>3]&(1<<(i&7)) != 0 {
+				n++
+			}
+		}
+		prefix = fmt.Sprintf("mask-prefix (%d bytes)", n)
+	case searchTableTypeLongPrefix:
+		prefix = fmt.Sprintf("long-prefix=%q", string(c.longPrefix))
+	default:
+		prefix = fmt.Sprintf("type=%d", c.tableType)
+	}
+	return fmt.Sprintf("matchLen=%d baseTableSize=%d (%d entries) %s",
+		c.matchLen, c.baseTableSize, 1<<c.baseTableSize, prefix)
+}
+
 // NewSearchTableConfig creates a search table config.
 // Defaults: matchLen=6, no prefix (type 1), auto table size, 70% max population, 25% max conflicts.
 func NewSearchTableConfig() SearchTableConfig {

--- a/search_table.go
+++ b/search_table.go
@@ -205,9 +205,11 @@ func hashValue4(v uint64, ts uint8) uint32 { return (uint32(v) * prime4bytes) >>
 func hashValue5(v uint64, ts uint8) uint32 {
 	return uint32(((v << 24) * prime5bytes) >> (64 - uint64(ts)))
 }
+
 func hashValue6(v uint64, ts uint8) uint32 {
 	return uint32(((v << 16) * prime6bytes) >> (64 - uint64(ts)))
 }
+
 func hashValue7(v uint64, ts uint8) uint32 {
 	return uint32(((v << 8) * prime7bytes) >> (64 - uint64(ts)))
 }

--- a/search_test.go
+++ b/search_test.go
@@ -715,11 +715,12 @@ func TestWriterSearchTable(t *testing.T) {
 		case chunkTypeSearchTable:
 			hasTable = true
 		}
-		if chunkType == ChunkTypeStreamIdentifier {
+		switch chunkType {
+		case ChunkTypeStreamIdentifier:
 			pos += 4 + magicBodyLen
-		} else if chunkType == chunkTypeUncompressedData || chunkType == chunkTypeMinLZCompressedData || chunkType == chunkTypeMinLZCompressedDataCompCRC {
+		case chunkTypeUncompressedData, chunkTypeMinLZCompressedData, chunkTypeMinLZCompressedDataCompCRC:
 			pos += 4 + chunkLen
-		} else {
+		default:
 			pos += 4 + chunkLen
 		}
 	}

--- a/writer.go
+++ b/writer.go
@@ -57,6 +57,13 @@ func NewWriter(w io.Writer, opts ...WriterOption) *Writer {
 	w2.obufLen = obufHeaderLen + MaxEncodedLen(w2.blockSize)
 	if w2.searchCfg != nil {
 		w2.searchMaxChunk = w2.searchCfg.maxChunkSize()
+		// 0x46 is only emitted when strictly smaller than 0x45, so on-wire size
+		// is bounded by the 0x45 size. A small headroom covers the worst-case
+		// transient layout (h0_bs + h0_tc + up to 16 disposition bytes + a few
+		// uvarint length prefixes).
+		if w2.searchCfg.compression != nil && w2.searchCfg.compression.enabled {
+			w2.searchMaxChunk += 64
+		}
 		w2.obufLen += w2.searchMaxChunk
 	}
 	w2.paramsOK = true
@@ -456,7 +463,7 @@ func (w *Writer) EncodeBuffer(buf []byte) (err error) {
 				}
 				table, reductions := searchCfg.buildSearchTable(uncompressed, overlap, stBuf, searchCfg.shouldPack(w.concurrency))
 				if table != nil {
-					searchLen = len(appendSearchTableChunk(obuf[:0], searchCfg, reductions, table))
+					searchLen = len(w.appendSearchTableEitherChunk(obuf[:0], reductions, table))
 				}
 				searchTablePool.Put(table)
 			}
@@ -604,7 +611,7 @@ func (w *Writer) write(p []byte) (nRet int, errRet error) {
 				table, reductions := searchCfg.buildSearchTable(uncompressed, overlap, stBuf, searchCfg.shouldPack(w.concurrency))
 				if table != nil {
 					// obuf still points to the pool buffer with smc space at front.
-					searchLen = len(appendSearchTableChunk(inbuf[:0], searchCfg, reductions, table))
+					searchLen = len(w.appendSearchTableEitherChunk(inbuf[:0], reductions, table))
 				}
 				searchTablePool.Put(table)
 			}
@@ -707,7 +714,7 @@ func (w *Writer) writeFull(inbuf []byte) (errRet error) {
 			if table != nil {
 				// Search chunk is in the original obuf (may have been swapped if incompressible,
 				// but we only reach here for compressible blocks so obuf is unchanged).
-				searchLen = len(appendSearchTableChunk(obuf[:0], searchCfg, reductions, table))
+				searchLen = len(w.appendSearchTableEitherChunk(obuf[:0], reductions, table))
 			}
 			searchTablePool.Put(table)
 		}
@@ -1172,6 +1179,25 @@ func (w *Writer) writeSearchTableSync(uncompressed, overlap []byte) error {
 	if table == nil {
 		return nil
 	}
+	// Try compressed form first. When emitted, the chunk is fully serialized
+	// (no large-bitmap separate write).
+	if w.searchCfg.compression != nil && w.searchCfg.compression.enabled {
+		e := cstEncoderPool.Get().(*cstEncoder)
+		out, ok, _ := appendSearchTableCompressedChunk(w.searchHdrBuf[:0], w.searchCfg, reductions, table, e)
+		cstEncoderPool.Put(e)
+		if ok {
+			w.searchHdrBuf = out
+			n, err := w.writer.Write(out)
+			if err != nil {
+				return w.err(err)
+			}
+			if n != len(out) {
+				return w.err(io.ErrShortWrite)
+			}
+			w.written += int64(n)
+			return nil
+		}
+	}
 	w.searchHdrBuf = appendSearchTableHeader(w.searchHdrBuf[:0], w.searchCfg, reductions, table)
 	n, err := w.writer.Write(w.searchHdrBuf)
 	if err != nil {
@@ -1190,6 +1216,21 @@ func (w *Writer) writeSearchTableSync(uncompressed, overlap []byte) error {
 	}
 	w.written += int64(n)
 	return nil
+}
+
+// appendSearchTableEitherChunk dispatches between the compressed (0x46) and
+// uncompressed (0x45) search-table chunk encoders. When compression is
+// disabled or not beneficial, falls back to 0x45.
+func (w *Writer) appendSearchTableEitherChunk(dst []byte, reductions uint8, table []byte) []byte {
+	if w.searchCfg.compression != nil && w.searchCfg.compression.enabled {
+		e := cstEncoderPool.Get().(*cstEncoder)
+		out, ok, _ := appendSearchTableCompressedChunk(dst, w.searchCfg, reductions, table, e)
+		cstEncoderPool.Put(e)
+		if ok {
+			return out
+		}
+	}
+	return appendSearchTableChunk(dst, w.searchCfg, reductions, table)
 }
 
 // WriterSearchTable enables per-block search table generation.

--- a/writer.go
+++ b/writer.go
@@ -1181,8 +1181,11 @@ func (w *Writer) writeSearchTableSync(uncompressed, overlap []byte) error {
 	// (no large-bitmap separate write).
 	if w.searchCfg.compression != nil && w.searchCfg.compression.enabled {
 		e := cstEncoderPool.Get().(*cstEncoder)
-		out, ok, _ := appendSearchTableCompressedChunk(w.searchHdrBuf[:0], w.searchCfg, reductions, table, e)
+		out, ok, err := appendSearchTableCompressedChunk(w.searchHdrBuf[:0], w.searchCfg, reductions, table, e)
 		cstEncoderPool.Put(e)
+		if err != nil {
+			return w.err(err)
+		}
 		if ok {
 			w.searchHdrBuf = out
 			n, err := w.writer.Write(out)
@@ -1218,12 +1221,17 @@ func (w *Writer) writeSearchTableSync(uncompressed, overlap []byte) error {
 
 // appendSearchTableEitherChunk dispatches between the compressed (0x46) and
 // uncompressed (0x45) search-table chunk encoders. When compression is
-// disabled or not beneficial, falls back to 0x45.
+// disabled or not beneficial, falls back to 0x45. An internal encoder error
+// is recorded on the Writer (visible to subsequent operations via w.err) so
+// it isn't silently masked by the 0x45 fallback.
 func (w *Writer) appendSearchTableEitherChunk(dst []byte, reductions uint8, table []byte) []byte {
 	if w.searchCfg.compression != nil && w.searchCfg.compression.enabled {
 		e := cstEncoderPool.Get().(*cstEncoder)
-		out, ok, _ := appendSearchTableCompressedChunk(dst, w.searchCfg, reductions, table, e)
+		out, ok, err := appendSearchTableCompressedChunk(dst, w.searchCfg, reductions, table, e)
 		cstEncoderPool.Put(e)
+		if err != nil {
+			_ = w.err(err)
+		}
 		if ok {
 			return out
 		}

--- a/writer.go
+++ b/writer.go
@@ -56,14 +56,10 @@ func NewWriter(w io.Writer, opts ...WriterOption) *Writer {
 	}
 	w2.obufLen = obufHeaderLen + MaxEncodedLen(w2.blockSize)
 	if w2.searchCfg != nil {
+		// 0x46 is only emitted when strictly smaller than the equivalent
+		// 0x45, so a single reservation of cfg.maxChunkSize() covers both
+		// chunk forms — no headroom needed.
 		w2.searchMaxChunk = w2.searchCfg.maxChunkSize()
-		// 0x46 is only emitted when strictly smaller than 0x45, so on-wire size
-		// is bounded by the 0x45 size. A small headroom covers the worst-case
-		// transient layout (h0_bs + h0_tc + up to 16 disposition bytes + a few
-		// uvarint length prefixes).
-		if w2.searchCfg.compression != nil && w2.searchCfg.compression.enabled {
-			w2.searchMaxChunk += 64
-		}
 		w2.obufLen += w2.searchMaxChunk
 	}
 	w2.paramsOK = true
@@ -118,8 +114,10 @@ type result struct {
 	startOffset int64
 }
 
-var errClosed = errors.New("minlz: Writer is closed")
-var errNilWriter = errors.New("minlz: Writer has not been set")
+var (
+	errClosed    = errors.New("minlz: Writer is closed")
+	errNilWriter = errors.New("minlz: Writer has not been set")
+)
 
 // err returns the previously set error.
 // If no error has been set it is set to err if not nil.
@@ -502,7 +500,7 @@ func (w *Writer) encodeBlock(obuf, uncompressed []byte) int {
 
 	if debugValidateBlocks && n > 0 {
 		fmt.Println("debugValidateBlocks:", len(uncompressed), "->", n)
-		//debug.PrintStack()
+		// debug.PrintStack()
 		src := uncompressed
 		block := obuf[:n]
 		dst := make([]byte, len(src))
@@ -512,9 +510,9 @@ func (w *Writer) encodeBlock(obuf, uncompressed []byte) int {
 			x := crc32.ChecksumIEEE(src)
 			name := fmt.Sprintf("errs/block-%08x-%d", x, ret)
 			fmt.Println(name, "mismatch at pos", n)
-			os.WriteFile(name+"input.bin", src, 0644)
-			os.WriteFile(name+"decoded.bin", dst, 0644)
-			os.WriteFile(name+"compressed.bin", block, 0644)
+			os.WriteFile(name+"input.bin", src, 0o644)
+			os.WriteFile(name+"decoded.bin", dst, 0o644)
+			os.WriteFile(name+"compressed.bin", block, 0o644)
 		}
 	}
 	return n


### PR DESCRIPTION
A stream can contain search indexes only. This means that blocks are referenced into another stream.

Adds chunk type 0x46: Compressed Block Search Table

Allows storing search indexes with entropy compression.

This will allow higher precision tables to be stored without loosing precision - other than the size increase from fewer collisions.

We allow for flexibility in the encoder while always keeping decoding fast.

`huff0` is about 500MB/s encoding and 2000MB/s decoding per thread and doesn't rely on any special CPU to be reasonably fast.

Adds chunk type "0x47: Remote Block Reference" to spec.

```
λ go build&&mz c -search -search.compress -search.lim=5 cockroach.node1.log && mz search -v "abcderterteartertfdgert" cockroach.node1.log.mz
Compressing cockroach.node1.log -> cockroach.node1.log.mz 10506623721 -> 999484530 [9.51% 10.512:1]; 3840.4MB/s
cockroach.node1.log.mz took 645ms 16289.3 MB/s
Blocks total: 1253, skipped: 1253 (100.0%), deferred: 17 (1.4%, 17 skipped)
Blocks searched: 0 (0.0%), false positive: 0 (0.0%)
Bytes skipped: 706028650 compressed, searched: 0 uncompressed
Tables: 1253 present, 0 missing, 0 unusable
Table bits/byte: 0.2234, log2: 23.0, avg reductions: 0.0
Table total: 293447084 bytes, avg 234195 bytes/table, 2.79% of 10506623721 uncompressed
Table population: avg 2.9%, min 1.9%, max 4.8%
Table types: 0 uncompressed (0x45), 1253 compressed (0x46)
Compressed tables: 1253 (100.0% of total), 293447084 wire bytes, 1313865728 uncompressed bitmap bytes (22.33% ratio)
huff0 sub-blocks: 20048 total (19916 tabled, 0 raw, 0 RLE, 132 sparse); 14129 tables emitted (share=0.71 tables/tabled-block)
  payload bytes: tabled=291446563 raw=0 RLE=0 sparse=1353246; table-header bytes=609685

λ go build&&mz c -search -search.compress -search.lim=5 -search.prefix="a" "cockroach.node1.log"&&mz search -v "abcderterteartertfdgert" "cockroach.node1.log.mz"
Compressing cockroach.node1.log -> cockroach.node1.log.mz 10506623721 -> 707476550 [6.73% 14.851:1]; 4283.9MB/s
cockroach.node1.log.mz took 74ms 141981.4 MB/s
Blocks total: 1253, skipped: 1252 (99.9%), deferred: 2 (0.2%, 2 skipped)
Blocks searched: 1 (0.1%), false positive: 1 (100.0%)
Bytes skipped: 705393872 compressed, searched: 8388608 uncompressed
Tables: 1253 present, 0 missing, 0 unusable
Table bits/byte: 0.0011, log2: 16.9, avg reductions: 6.1
Table total: 1439128 bytes, avg 1148 bytes/table, 0.01% of 10506623721 uncompressed
Table population: avg 0.7%, min 0.5%, max 1.0%
Table types: 0 uncompressed (0x45), 1253 compressed (0x46)
Compressed tables: 1253 (100.0% of total), 1439128 wire bytes, 20627456 uncompressed bitmap bytes (6.98% ratio)
huff0 sub-blocks: 1254 total (0 tabled, 0 raw, 0 RLE, 1254 sparse); 0 tables emitted (share=0.00 tables/tabled-block)
  payload bytes: tabled=0 raw=0 RLE=0 sparse=1410308; table-header bytes=0
```

# New Blocks

### 2.2 Compressed Block Search Table (chunk type 0x46, skippable)

The Compressed Block Search Table is an optional chunk that will come before a block that represents the contents.

| Length     | Code  | Description                    |
|------------|-------|--------------------------------|
| 1          |       | Table Type                     |
| 1          |       | Search pattern length          |
| 1          |       | Base Table Size in log2        |
| 0/8/32/1+n |       | Prefix values                  |
| 1          |       | Reductions from Base Table     |
| 4          |       | CRC32 of table entries         |
| 1          | h0_bs | log2 huff0 block size          |
| 1          | h0_tc | huff0 table count              |
| ...        |       | huff0 tables                   |
| 1          | h0_ti | huff0 table index              |
| 1-3        | bd    | compressed length (uvarint)    |
| bd         |       | huff0 4X compressed block data |
| ...        |       | Additional huff0 blocks        |

See Section 2.1 on how to decode table information until the huff0 section.

The index bits are split into huff0 blocks.

The first value (h0_bs) is the log2 of the uncompressed huff0 block size in bytes.
The bitmap size (n) must be divisible by the huff0 block size.
The maximum huff0 block size is 128KiB (h0_bs = 17).
The minimum size is 32 bytes (h0_bs = 5).

Tables for huff0 blocks are stored separately. There can be up to 16 tables per block.
The encoder is allowed to reuse tables for different huff0 blocks.

The encoded huff0 tables follow. This is similar to zstd, [rfc 8878](https://datatracker.ietf.org/doc/html/rfc8878#section-4.2).
Table sizes are self-contained, but h0_tc must be read.

The number of blocks can be calculated as `n / (1 << h0_bs)`.

For each block the table index is specified by the h0_ti value and decoded as follows:

| h0_ti value | Meaning                                   |
|-------------|-------------------------------------------|
| 0 -> 15     | huff0 table index                         |
| 16          | Uncompressed block                        |
| 17          | RLE - Read 1 byte, repeat value for block |
| 18          | Sparse Bit Table                          |
| 19 -> 255   | Reserved [invalid]                        |  

If h0_ti is <= 15, the compressed size follows as a uvarint - and the compressed data itself.
Note the compressed streams are always [4 streams interleaved](https://datatracker.ietf.org/doc/html/rfc8878#name-jump_table),
also named 4X in zstd.

An uncompressed block (h0_ti = 16) and RLE (h0_ti = 17) will not have any size,
since that can be inferred.

RLE in this context means "single value repeated for the entire block" and can only be used for that.

#### 2.2.1 Sparse Bit Table

A sparse bit table can be used for very sparsely populated blocks.

Like huff0 block, this starts with a uvarint encoded length in bytes.

The block contains byte-encoded distances between bits.

To decode, read single bytes. Each byte is the distance to the next set bit.
Bits are counted from the least significant bit.

If the byte is 255, add 255 to the distance and read the following byte.

When the final byte has been read, there are no more bits. 
The distance is not expected to reach the end of the block. 

### 2.3 Remote Block Reference (chunk type 0x47, skippable)

When generating search indexes from an existing stream or you, for
another reason, want to separate the search index from the data,
you can use the Remote Block Reference chunk type to indicate a remote block.

| Length  | Description                         |
|---------|-------------------------------------|
| UVarInt | Block Offset                        |
| ...     | [Additional relative block offsets] |

This block replaces a block that and indicates the offset of the block in the stream.

If more values are present, it indicates additional blocks without indexes between.
These are stored as relative offsets from the current block.

The block offsets must be in strictly ascending order.
