### PR TITLE
Improve prefix indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ compression ratio while retaining a high decompression speed.
 * Detailed control of memory under decompression
 * Fast detection of pre-compressed data
 * Powerful commandline utility
+* Customizable Bloom Filter Stream Search 
 
 This package implements the MinLZ specification v1.0 in Go.
 

--- a/SEARCH.md
+++ b/SEARCH.md
@@ -55,6 +55,17 @@ and searching will have to fall back to decompression.
 
 MinLZ will not attempt to generate tables for incompressible blocks.
 
+### Streaming, concurrency and flushing
+
+Search tables work with every writer mode (`Write`, `EncodeBuffer`, `ReadFrom`,
+any `WriterConcurrency`). To index a block's boundary windows the encoder needs
+the first few bytes of the *next* block, so a streaming `Write` holds one block
+back until the following data arrives (or `Close`). A block forced out by an
+explicit mid-stream `Flush` has no following bytes yet, so it is written
+**without** a search table — it stays fully searchable but is always scanned
+(never skipped). `EncodeBuffer` and ordinary streaming index every non-final
+block, so skipping is unaffected.
+
 ## Parameters
 
 ### Match Length

--- a/SPEC_SEARCH.md
+++ b/SPEC_SEARCH.md
@@ -579,20 +579,25 @@ block can check the boundary region. If a block is skipped, the previous block
 reference should be cleared.
 
 For each decoded block, the boundary check examines:
-- The last `len(pattern)-1` bytes of the previous block
+- The last `len(pattern)-1` bytes of the contiguously decoded data preceding the block
 - The first `len(pattern)-1` bytes of the current block
 
 If the concatenation of these regions contains the pattern, it is a boundary match.
-This requires the previous block to have been decoded (not skipped). The overlap
+The preceding region is a rolling tail of the most recent contiguous run of decoded
+blocks — **not** just the single previous block. A short interior block (e.g. one
+emitted by a mid-stream `Flush`) may be shorter than `len(pattern)-1`, so a single
+match can straddle three or more blocks; the tail must therefore span as many prior
+blocks as needed to cover `len(pattern)-1` bytes. The tail is reset whenever a block
+is skipped or deferred (its bytes are not decoded, breaking contiguity). The overlap
 indexing in B.1 ensures that if a pattern starts in block N, block N's table has
 the first window set (for type 1) or the raw first window set (for prefix types,
-via the overlap tail), so block N is decoded and available as PrevBlock for block N+1.
+via the overlap tail), so block N is decoded and contributes to the tail for block N+1.
 
-A searcher should not skip a block if the previous block was decoded and a
-boundary match is possible. A boundary match is possible only when some suffix
-of the previous block's tail (`last len(pattern)-1 bytes`) is a prefix of the
-search pattern. If no such overlap exists, the block can safely be skipped and
-the previous block reference cleared.
+A searcher should not skip a block if the boundary tail could start a match reaching
+into it. A boundary match is possible only when some suffix of that tail
+(`last len(pattern)-1 bytes` of the preceding contiguous decoded data) is a prefix of
+the search pattern. If no such overlap exists, the block can safely be skipped and the
+tail cleared.
 
 When a block is decoded solely for a boundary check (the table indicates no
 match within the block), the previous block reference should be cleared

--- a/SPEC_SEARCH.md
+++ b/SPEC_SEARCH.md
@@ -307,9 +307,15 @@ be satisfied. An overlap position is only indexed if its preceding byte in the b
 data is a valid prefix value. This means:
 
 - A prefix byte at the end of block N followed by a value starting in block N+1
-  WILL be indexed in block N's table (the prefix is in block N's data).
-- A value at the start of block N where the prefix byte is the last byte of block N-1
-  will NOT be indexed in block N's table, but only in block N-1's table.
+  WILL be indexed in block N's table (the prefix is in block N's data). This
+  includes the case where the prefix byte is block N's very last byte: the
+  encoder reads the value from the overlap (the first `matchLen` bytes of block
+  N+1) and records it in block N, because block N+1 cannot index it — its
+  position 0 has no preceding prefix byte. See Appendix B.1 and B.4.3.
+- For a multi-byte (long) prefix that STARTS in block N but straddles into block
+  N+1, the occurrence is likewise indexed in block N — the block where the prefix
+  starts — reading the remainder of the prefix and the value from the overlap.
+  Block N+1 cannot index it (its prefix is only partly in block N+1's data).
 
 An empty prefix table (all zero bits) indicates that no prefix bytes exist
 in the block, allowing the searcher to skip it entirely.
@@ -345,9 +351,11 @@ hashes are written for `Extra Matches + 1` consecutive overlapping windows at po
 windows collectively span bytes `[P+pl, P+pl+matchLen+Extra Matches)` of the data.
 
 All `Extra Matches + 1` hash entries for one prefix occurrence are stored in the same
-block's search table — the block containing the prefix bytes. The encoder's tail-overlap
-into the next block must therefore cover `matchLen + Extra Matches - 1` bytes (rather than
-`matchLen - 1`), so that all windows can be read for prefix positions near the block end.
+block's search table — the block where the prefix STARTS. The encoder's tail-overlap
+into the next block must therefore cover `len(prefix) - 1 + matchLen + Extra Matches`
+bytes (rather than `matchLen`), so that every occurrence whose prefix starts in this
+block can read its windows from the overlap — including a prefix that itself straddles
+the boundary, and the position whose last prefix byte is the block's last byte.
 
 The prefix (1 to 256 bytes) is stored after the length indication and the extras byte.
 
@@ -473,18 +481,27 @@ requires this (section 3: "The block table must include patterns that start in t
 upcoming block and continue into the next block").
 
 For block N of size S with matchLen M, the positions that need overlap are
-`S-M+1` through `S-1`. Each of these positions reads bytes from both block N
-and block N+1. The encoder should provide the first `M-1` bytes of block N+1
-as overlap when building block N's table.
+`S-M+1` through `S`. Each reads bytes from both block N and block N+1. Position
+`S` is the window whose prefix byte is block N's last byte; prefix tables index
+it (block N+1 cannot — see 3.3.1), while no-prefix tables stop at `S-1` because
+block N+1 indexes that window at its own position 0. The encoder should provide
+the first `M` bytes of block N+1 as overlap when building block N's table (`M-1`
+suffices for no-prefix tables).
 
-For type 4 tables with `Extra Matches = E > 0`, every indexed prefix occurrence
-contributes `E+1` consecutive windows. The encoder must therefore read up to
-`M + E - 1` bytes past the block end, so the overlap from block N+1 must extend
-to `M + E - 1` bytes for type 4 tables with extras.
+For type 4 (long prefix) tables the prefix is `pl` bytes and may itself straddle the
+boundary, and with `Extra Matches = E` every indexed occurrence contributes `E+1`
+consecutive windows. An occurrence is indexed in the block where its prefix STARTS
+(see 3.3.1). The encoder must therefore read up to `(pl-1) + M + E` bytes past the
+block end, so the overlap from block N+1 must extend to `pl - 1 + M + E` bytes for
+type 4 tables. (Types 2 and 3 have `pl = 1`, giving the `M + E` requirement above.)
 
 For contiguous buffers (`EncodeBuffer`), the overlap is directly available.
-For streaming writes, the overlap comes from the remaining data in the write buffer.
-The last block in a stream has no overlap — its tail positions cannot be indexed.
+For streaming writes the encoder **defers** a block until the next block's bytes
+are buffered, so every non-final block is tabled with its full overlap. A block
+forced out without that overlap — a mid-stream `Flush` — is emitted with **no
+search table** (it is always scanned at search time; see B.4.3). The final block
+in a stream has no successor, so its missing forward overlap is harmless and it
+keeps its table.
 
 **Prefix tables and overlap:** For prefix-filtered tables (types 2, 3, 4), the overlap
 tail positions must still respect the prefix context. An overlap position is only indexed
@@ -492,7 +509,7 @@ if its preceding byte in the block data is a valid prefix byte. This ensures tha
 tables remain accurate — an empty prefix table correctly indicates "no prefix bytes exist
 in this block" and the block can be skipped for any prefix-aware search.
 
-Implementation note: the overlap positions are few (at most `M-1 = 7` for matchLen 8)
+Implementation note: the overlap positions are few (at most `M = 8` for matchLen 8)
 and can be handled with a small stack buffer rather than concatenating the full block
 with the overlap bytes.
 
@@ -628,47 +645,39 @@ match to remain possible. If even one is absent, the match cannot exist.
 The savings come from avoiding decompression of false-positive blocks. The
 compressed data must still be read (or seeked past) to advance the stream.
 
-#### B.4.3 Prefix Tables: Safe Deferral Conditions
+#### B.4.3 Prefix Tables: Tabled Blocks Carry Full Overlap
 
-For prefix tables (types 2, 3, 4), not all absent windows can be safely
-deferred. The issue: block N+1's table builder cannot see prefix bytes that
-are in block N (section 3.3.1). For a boundary match, continuation windows
-whose prefix bytes fall within block N will NOT be indexed in block N+1's
-table, producing false negatives if checked.
+The deferred check (B.4.1) verifies absent windows against block N+1's table.
+For prefix tables (types 2, 3, 4) this is sound because of an encoder invariant:
+a block's search table is emitted **only when the encoder had the block's full
+forward overlap** (`len(prefix) - 1 + matchLen + Extra Matches` bytes of the next
+block; see B.1). The encoder records, for every prefix occurrence that STARTS in
+block N — including one whose prefix byte is its last byte, or whose multi-byte
+prefix straddles into block N+1 — all `Extra Matches + 1` windows that follow it
+(section 3.3.1, B.1). So a tabled block holds every prefix-context window of every
+occurrence starting in it; there is no boundary "blind spot".
 
-Two conditions must both be met for safe deferral:
+When the overlap is unavailable — a mid-stream `Flush`, where the next block's
+bytes don't exist yet — the block is emitted with **no search table** (its `0x47`
+ref, in sidecar mode, is still written). A tableless block is always scanned, so
+a match straddling that boundary is still found via the decoded-block boundary
+check (B.2/B.3); it simply can't be skipped. The stream's final block has no
+successor (hence no forward straddle), so it keeps its table.
 
-**Condition 1 — Position threshold.** Let `iFirst` be the pattern position
-of the first prefix-context window. For a boundary match via the overlap
-region, at most `matchLen - 1 + iFirst` pattern bytes can be in block N.
-A continuation window at pattern position `j` has its prefix byte at
-`pattern[j-1]`, which is in block N+1 only when `j >= matchLen + iFirst`.
-Only absent windows above this threshold may be deferred.
+**Deferral rule.** Because every tabled block carries full overlap, for a real
+match straddling N→N+1 every window absent from block N's table is present in
+block N+1's table. The searcher therefore defers **all** absent windows after the
+first present one and skips block N if any is missing from N+1 — the same rule as
+the no-prefix path (B.4.1), with no special boundary handling.
 
-For type 4 (long prefix) with prefix length `K`, the threshold is
-`matchLen + K + iFirst`.
+For type 4 (long prefix) with `Extra Matches = E` the same defer-all rule applies:
+each pattern occurrence contributes `E+1` windows, all stored together in the
+prefix-start block, so the absent windows of every occurrence after the first
+present one are deferred and checked against block N+1's table.
 
-**Condition 2 — Near window confirmation.** The position threshold is only
-valid when the match is within the overlap range (K ≤ matchLen - 1 + iFirst).
-If the first prefix window's hash was set by a normal (non-overlap) position
-deeper in the block, K can exceed the overlap range and the threshold is
-insufficient.
-
-To confirm the overlap range: check whether any prefix window between
-`iFirst` and the threshold ("near" windows) is absent from block N's table.
-If a near window is absent, K cannot exceed the overlap range — otherwise
-the near window would be at a normal position within block N and would be
-present. If ALL near windows are present, K might exceed the overlap range
-and deferral must be skipped (decode conservatively).
-
-**Raw fallback.** When the first prefix window is absent but the raw hash
-is present, K ≤ iFirst (the first prefix window would be within block N for
-larger K and would be present). The near-window condition is inherently
-satisfied (the first prefix window itself is absent). The position threshold
-still applies.
-
-If no windows meet the threshold, or the near-window condition is not met,
-deferral is not possible and the block must be decoded.
+**Raw fallback.** When the first prefix window is absent but the raw first window
+is present (the pattern's leading prefix byte lies in the previous block), the
+absent windows are deferred only when that raw window is set in block N's table.
 
 #### B.4.4 Limitations
 

--- a/cmd/mz/search.go
+++ b/cmd/mz/search.go
@@ -24,6 +24,7 @@ func mainSearch(args []string) {
 		quiet     = fs.Bool("q", false, "Quiet: only set exit code (0=found, 1=not found)")
 		lines     = fs.Bool("l", true, "Print matching lines instead of whole blocks")
 		verbose   = fs.Bool("v", false, "Print data")
+		winStats  = fs.Bool("window-stats", false, "Print per-pattern-window table presence counts after the search (implies -v)")
 		sidecar   = fs.String("sidecar", "", "Search using the given sidecar (.mzs) file; the input must support random access. If empty, <input>"+minlzSidecarExt+" is auto-detected when present.")
 		noSidecar = fs.Bool("no-sidecar", false, "Disable sidecar auto-detection; force inline search")
 		help      = fs.Bool("help", false, "Display help")
@@ -50,6 +51,7 @@ Options:`)
 	_ = noColor
 	pattern := []byte(args[0])
 	files := args[1:]
+	verboseOut := *verbose || *winStats
 
 	exitCode := 1 // 1 = not found
 	multiFile := len(files) > 1
@@ -72,7 +74,7 @@ Options:`)
 				bail:      *bail,
 				quiet:     *quiet,
 				lines:     *lines,
-				verbose:   *verbose,
+				verbose:   verboseOut,
 				multiFile: multiFile,
 				sidecar:   *sidecar,
 				noSidecar: *noSidecar,
@@ -84,11 +86,15 @@ Options:`)
 			if found {
 				exitCode = 0
 			}
-			if *verbose {
+			if verboseOut {
 				elapsed := time.Since(start).Round(time.Millisecond)
 				mbps := float64(stats.UncompressedSize) / elapsed.Seconds() / 1e6
 				fmt.Fprintf(os.Stderr, "%s took %v %.01f MB/s\n", file, elapsed, mbps)
-				stats.Fprint(os.Stderr)
+				if *winStats {
+					stats.FprintExtended(os.Stderr)
+				} else {
+					stats.Fprint(os.Stderr)
+				}
 			}
 		}
 	}

--- a/internal/reference/search_encoder.go
+++ b/internal/reference/search_encoder.go
@@ -112,7 +112,7 @@ func HashValue(val uint64, tableSize, matchLen uint8) uint32 {
 }
 
 // BuildSearchTable produces the packed bitmap and the chosen reductions count
-// for blockData. overlap is up to MatchLen+Extras-1 bytes from the start of
+// for blockData. overlap is up to MatchLen+Extras bytes from the start of
 // the next block (empty for the last block in a stream).
 //
 // The returned table length is 1 << (BaseTableSize - reductions - 3) bytes,
@@ -162,9 +162,51 @@ func BuildSearchTable(cfg SearchConfig, blockData, overlap []byte) (table []byte
 	// Overlap tail: positions whose windows extend into the next block.
 	// Only emitted when overlap data is available — the last block of a stream
 	// has no overlap, so its tail positions are not indexed.
+	//
+	// Prefix tables also index position len(blockData): the window whose prefix
+	// byte is the block's last byte begins in the next block and cannot be
+	// indexed there (it would be position 0), so block N records it (3.3.1).
 	if len(overlap) > 0 {
-		for pos := last; pos < len(blockData); pos++ {
+		end := len(blockData)
+		if cfg.TableType != TableTypeNoPrefix {
+			end = len(blockData) + 1
+		}
+		for pos := last; pos < end; pos++ {
 			indexAt(pos)
+		}
+	}
+
+	// Long prefix: index occurrences whose prefix starts in this block but
+	// straddles into the next (window-start past the block end). The spec puts
+	// an occurrence in the block where its prefix starts; block N+1 can't index
+	// it (its prefix is partly here). Read the prefix tail and window(s) from
+	// the overlap. Single-byte prefixes can't straddle.
+	if len(overlap) > 0 && cfg.TableType == TableTypeLongPrefix {
+		pl := len(cfg.LongPrefix)
+		s := len(blockData)
+		for q := max(0, s-pl+1); q < s; q++ {
+			k := s - q // prefix bytes inside this block (1..pl-1)
+			if pl-k > len(overlap) {
+				continue
+			}
+			ok := true
+			for i := 0; i < k && ok; i++ {
+				ok = blockData[q+i] == cfg.LongPrefix[i]
+			}
+			for i := 0; i < pl-k && ok; i++ {
+				ok = overlap[i] == cfg.LongPrefix[k+i]
+			}
+			if !ok {
+				continue
+			}
+			woff := q + pl - s // window start within overlap
+			for j := 0; j <= ex; j++ {
+				off := woff + j
+				if off > len(overlap) {
+					off = len(overlap)
+				}
+				setBit(table, HashValue(readLE64Pad(overlap[off:]), cfg.BaseTableSize, cfg.MatchLen))
+			}
 		}
 	}
 

--- a/search_index.go
+++ b/search_index.go
@@ -90,7 +90,16 @@ func (c *SearchTableConfig) buildSearchTable(blockData, overlap, dst []byte, pac
 		ex := int(c.extras)
 		var tmp [16]byte
 		start := max(0, len(blockData)-ml-ex+1)
-		for pos := start; pos < len(blockData); pos++ {
+		// Prefix tables additionally index position len(blockData): the window
+		// whose prefix byte is the block's LAST byte. It begins in the next
+		// block, and block N+1 cannot index it (that would be N+1's position 0,
+		// whose prefix byte is in block N), so block N records it to keep the
+		// index complete. See SPEC_SEARCH.md 3.3.1 / B.1.
+		end := len(blockData)
+		if c.tableType != searchTableTypeNoPrefix {
+			end = len(blockData) + 1
+		}
+		for pos := start; pos < end; pos++ {
 			// For prefix tables, only index if the preceding byte is a prefix.
 			if pos > 0 {
 				switch c.tableType {
@@ -123,6 +132,31 @@ func (c *SearchTableConfig) buildSearchTable(blockData, overlap, dst []byte, pac
 			copy(tmp[n:], overlap)
 			for j := 0; j <= ex; j++ {
 				setBit(table, hashValue(readLE64Pad(tmp[j:j+ml]), c.baseTableSize, c.matchLen))
+			}
+		}
+	}
+
+	// Long prefix: index occurrences whose prefix STARTS in this block but
+	// straddles into the next (window-start past the block end). The spec puts
+	// an occurrence in the block where its prefix starts; block N+1 can't index
+	// it (its prefix is partly here). Read the prefix tail and window(s) from
+	// the overlap. Single-byte prefixes (types 2/3) can't straddle.
+	if len(overlap) > 0 && c.tableType == searchTableTypeLongPrefix {
+		ex := int(c.extras)
+		pl := len(c.longPrefix)
+		s := len(blockData)
+		for q := max(0, s-pl+1); q < s; q++ {
+			k := s - q // prefix bytes inside this block (1..pl-1)
+			if !matchPrefix(blockData[q:s], c.longPrefix[:k]) {
+				continue
+			}
+			if pl-k > len(overlap) || !matchPrefix(overlap[:pl-k], c.longPrefix[k:]) {
+				continue
+			}
+			woff := q + pl - s // window start within overlap
+			for j := 0; j <= ex; j++ {
+				off := min(woff+j, len(overlap))
+				setBit(table, hashValue(readLE64Pad(overlap[off:]), c.baseTableSize, c.matchLen))
 			}
 		}
 	}

--- a/search_reader.go
+++ b/search_reader.go
@@ -260,6 +260,15 @@ type BlockSearcher struct {
 	decoded   [2][]byte // alternating decode buffers
 	decIdx    int       // which buffer was last used (0 or 1)
 	prevBlock []byte    // points into decoded[(decIdx+1)&1], nil if skipped
+	// tailBuf holds the last len(pattern)-1 bytes of the current contiguous run
+	// of scanned blocks, so a match straddling 3+ blocks (e.g. across a short
+	// Flush block whose length is < len(pattern)-1) is still found by the
+	// boundary scan. tailOff is its stream offset; bbuf is reused scratch for
+	// the boundary region. Reset whenever a block is skipped or deferred
+	// (i.e. not decoded), which breaks contiguity with the next block.
+	tailBuf []byte
+	tailOff int64
+	bbuf    []byte
 	// prevLazy is *lazyBlock so it can carry a nil sentinel meaning "no
 	// lazy prev." When set by bufferSkippedBlock / resolvePending, it
 	// always points at &prevLazyStore — the backing storage is reused
@@ -365,6 +374,7 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 	s.deferred = nil
 	s.pending = nil
 	s.prevLazy = nil
+	s.tailBuf = s.tailBuf[:0]
 
 	if s.collectStats {
 		defer func() { s.stats.UncompressedSize = s.blockStart }()
@@ -592,7 +602,7 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 				canUse, match := patternCanMatch(&savedInfo, savedTable, savedReductions, pattern)
 				s.blockTable = nil
 				if canUse && !match {
-					if s.prevBlock == nil || !canBoundaryMatch(s.prevBlock, pattern) {
+					if len(s.tailBuf) == 0 || !canBoundaryMatch(s.tailBuf, pattern) {
 						// Definite skip — buffer compressed data for lazy PrevBlock.
 						decompLen, err := s.bufferSkippedBlock(chunkType, chunkLen)
 						if err != nil {
@@ -609,6 +619,7 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 							}
 						}
 						s.prevBlock = nil
+						s.tailBuf = s.tailBuf[:0]
 						continue
 					}
 					tableNoMatch = true
@@ -617,7 +628,7 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 					// Don't defer if the previous block could have a boundary
 					// match into this block — deferral would skip that check.
 					dh := patternDeferHashes(&savedInfo, savedTable, savedReductions, pattern)
-					if dh != nil && (s.prevBlock == nil || !canBoundaryMatch(s.prevBlock, pattern)) {
+					if dh != nil && (len(s.tailBuf) == 0 || !canBoundaryMatch(s.tailBuf, pattern)) {
 						deferrable = true
 						// Buffer compressed data and defer decode.
 						decompLen, err := s.bufferSkippedBlock(chunkType, chunkLen)
@@ -635,6 +646,7 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 							s.stats.BlocksDeferred++
 						}
 						s.prevBlock = nil
+						s.tailBuf = s.tailBuf[:0]
 						continue
 					}
 				}
@@ -741,7 +753,7 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 				canUse, match := patternCanMatch(&s.blockInfo, s.blockTable, s.blockReductions, pattern)
 				s.blockTable = nil
 				if canUse && !match {
-					if s.prevBlock == nil || !canBoundaryMatch(s.prevBlock, pattern) {
+					if len(s.tailBuf) == 0 || !canBoundaryMatch(s.tailBuf, pattern) {
 						decompLen, err := s.bufferSkippedBlock(chunkType, chunkLen)
 						if err != nil {
 							return err
@@ -757,6 +769,7 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 							}
 						}
 						s.prevBlock = nil
+						s.tailBuf = s.tailBuf[:0]
 						continue
 					}
 					tableNoMatch = true
@@ -856,6 +869,26 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 	}
 }
 
+// updateTail records blk (ending at stream offset endOff) as the most recent
+// contiguous decoded data, retaining its last keep bytes for the next block's
+// boundary scan. Short blocks accumulate so the tail always spans keep bytes
+// when that much contiguous data exists.
+func (s *BlockSearcher) updateTail(blk []byte, endOff int64, keep int) {
+	if keep <= 0 {
+		s.tailBuf = s.tailBuf[:0]
+		return
+	}
+	if len(blk) >= keep {
+		s.tailBuf = append(s.tailBuf[:0], blk[len(blk)-keep:]...)
+	} else {
+		if drop := len(s.tailBuf) + len(blk) - keep; drop > 0 {
+			s.tailBuf = append(s.tailBuf[:0], s.tailBuf[min(drop, len(s.tailBuf)):]...)
+		}
+		s.tailBuf = append(s.tailBuf, blk...)
+	}
+	s.tailOff = endOff - int64(len(s.tailBuf))
+}
+
 // dispatchMatches finds all pattern occurrences in blk and calls fn for each.
 // If fn returns ErrSearchForward, the match is saved as s.deferred for the main
 // loop to re-dispatch after loading the next block. Remaining matches in this
@@ -870,42 +903,67 @@ func (s *BlockSearcher) dispatchMatches(blk []byte, blockOff int64, pattern []by
 		}
 	}
 
-	// Check for matches spanning the boundary between prevBlock and blk.
-	if s.prevBlock != nil && len(pattern) > 1 {
-		tail := s.prevBlock[max(0, len(s.prevBlock)-len(pattern)+1):]
+	// Check for matches spanning the boundary into blk. tailBuf holds the last
+	// len(pattern)-1 decoded bytes of the contiguous run ending at blk's start,
+	// so this also finds matches that straddle 3+ blocks across a short interior
+	// block (e.g. a 1-byte Flush block) — prevBlock alone may be too short.
+	if len(s.tailBuf) > 0 && len(pattern) > 1 {
+		tail := s.tailBuf
 		head := blk[:min(len(blk), len(pattern)-1)]
-		boundary := append(tail, head...)
+		s.bbuf = append(append(s.bbuf[:0], tail...), head...)
 		bOff := 0
 		for {
-			idx := bytes.Index(boundary[bOff:], pattern)
+			idx := bytes.Index(s.bbuf[bOff:], pattern)
 			if idx < 0 {
 				break
 			}
-			// Only report matches that actually straddle the boundary
-			// (start in prevBlock, end in blk).
+			// Only report matches that actually straddle (start in the tail,
+			// end in blk).
 			absIdx := bOff + idx
-			matchInPrev := len(tail) - absIdx
-			if matchInPrev <= 0 || matchInPrev >= len(pattern) {
+			matchInTail := len(tail) - absIdx
+			if matchInTail <= 0 || matchInTail >= len(pattern) {
 				bOff = absIdx + 1
 				continue
 			}
-			streamOff := blockOff - int64(matchInPrev)
-			result := SearchResult{
-				Blocks:       [2][]byte{s.prevBlock, blk},
-				Offset:       len(s.prevBlock) - matchInPrev,
-				StreamOffset: streamOff,
-				BlockStart:   prevBlockStart,
-				PrevBlockLen: len(s.prevBlock),
+			streamOff := s.tailOff + int64(absIdx)
+			// Prefer the full previous block for context; fall back to the tail
+			// when the match starts before prevBlock (a 3+ block straddle).
+			var result SearchResult
+			var defOff int
+			var defStart int64
+			var defBlk []byte
+			if s.prevBlock != nil && streamOff >= prevBlockStart {
+				off := int(streamOff - prevBlockStart)
+				result = SearchResult{
+					Blocks:       [2][]byte{s.prevBlock, blk},
+					Offset:       off,
+					StreamOffset: streamOff,
+					BlockStart:   prevBlockStart,
+					PrevBlockLen: len(s.prevBlock),
+				}
+				defOff, defStart, defBlk = off, prevBlockStart, s.prevBlock
+			} else {
+				result = SearchResult{
+					Blocks:       [2][]byte{tail, blk},
+					Offset:       absIdx,
+					StreamOffset: streamOff,
+					BlockStart:   s.tailOff,
+					PrevBlockLen: len(tail),
+				}
+				defOff, defStart = absIdx, s.tailOff
 			}
 			s.blockMatches++
 			err := fn(result)
 			if err != nil {
 				if errors.Is(err, ErrSearchForward) {
+					if defBlk == nil { // tailBuf is reused next block; copy it
+						defBlk = append([]byte(nil), tail...)
+					}
 					s.deferred = &deferredMatch{
 						streamOff: streamOff,
-						blockOff:  blockOff - int64(len(s.prevBlock)),
-						matchOff:  len(s.prevBlock) - matchInPrev,
-						blk:       s.prevBlock,
+						blockOff:  defStart,
+						matchOff:  defOff,
+						blk:       defBlk,
 					}
 				} else {
 					return err
@@ -919,6 +977,7 @@ func (s *BlockSearcher) dispatchMatches(blk []byte, blockOff int64, pattern []by
 	for {
 		idx := bytes.Index(blk[off:], pattern)
 		if idx < 0 {
+			s.updateTail(blk, blockOff+int64(len(blk)), len(pattern)-1)
 			return nil
 		}
 		matchOff := off + idx
@@ -1116,6 +1175,7 @@ func (s *BlockSearcher) resolvePending(pattern []byte, fn func(SearchResult) err
 		s.prevLazyStore = p.lazy
 		s.prevLazy = &s.prevLazyStore
 		s.prevBlock = nil
+		s.tailBuf = s.tailBuf[:0]
 		return nil
 	}
 

--- a/search_reader.go
+++ b/search_reader.go
@@ -1444,37 +1444,41 @@ func patternDeferHashes(cfg *SearchTableConfig, table []byte, reductions uint8, 
 		return deferHashesWithPrefixMask(cfg, table, mask, &cfg.prefixMask, pattern)
 
 	case searchTableTypeLongPrefix:
-		// TODO: re-enable deferred path for extras > 0. With E+1 windows per
-		// occurrence the threshold logic must be adjusted to account for the
-		// expanded boundary range.
-		if cfg.extras != 0 {
-			return nil
-		}
 		ml := int(cfg.matchLen)
+		ex := int(cfg.extras)
 		pl := len(cfg.longPrefix)
-		if len(pattern) < ml {
+		if len(pattern) < pl+ml+ex {
 			return nil
 		}
+		// Defer every absent window after the first occurrence whose windows are
+		// all present. The encoder records an occurrence in the block where its
+		// prefix starts — including a prefix that straddles into the next block
+		// (SPEC_SEARCH.md 2.1 / B.1) — so a real straddle's absent windows are all
+		// present in the next block's table. Handles extras (E+1 windows each).
 		first := true
-		firstPresent := false
-		safeThreshold := 0
+		firstAllPresent := false
 		var absent []uint32
-		for i := 0; i <= len(pattern)-pl-ml; i++ {
+		for i := 0; i <= len(pattern)-pl-ml-ex; i++ {
 			if !bytes.Equal(pattern[i:i+pl], cfg.longPrefix) {
 				continue
 			}
-			h := hashValue(readLE64Pad(pattern[i+pl:]), cfg.baseTableSize, cfg.matchLen)
-			present := table[(h&mask)>>3]&(1<<((h&mask)&7)) != 0
+			allPresent := true
+			var occAbsent []uint32
+			for j := 0; j <= ex; j++ {
+				h := hashValue(readLE64Pad(pattern[i+pl+j:]), cfg.baseTableSize, cfg.matchLen)
+				if table[(h&mask)>>3]&(1<<((h&mask)&7)) == 0 {
+					allPresent = false
+					occAbsent = append(occAbsent, h)
+				}
+			}
 			if first {
-				firstPresent = present
-				safeThreshold = ml + pl + i
+				firstAllPresent = allPresent
 				first = false
+				continue
 			}
-			if !present && i >= safeThreshold {
-				absent = append(absent, h)
-			}
+			absent = append(absent, occAbsent...)
 		}
-		if !firstPresent || len(absent) == 0 {
+		if !firstAllPresent || len(absent) == 0 {
 			return nil
 		}
 		return absent
@@ -1488,10 +1492,13 @@ func deferHashesWithPrefixMask(cfg *SearchTableConfig, table []byte, mask uint32
 		return nil
 	}
 
+	// Defer every absent window after the first present one. The encoder emits a
+	// table only for a block that had its full forward overlap (a flushed block
+	// without it emits no table and is always scanned), so for a real
+	// boundary-straddling match every window absent here is present in the next
+	// block's table — no window is recorded in neither block.
 	first := true
 	firstPresent := false
-	safeThreshold := 0  // pattern positions >= this are safe to defer
-	nearAbsent := false // any prefix window between iFirst and safeThreshold absent?
 	var absent []uint32
 	for i := 1; i <= len(pattern)-ml; i++ {
 		b := pattern[i-1]
@@ -1502,41 +1509,26 @@ func deferHashesWithPrefixMask(cfg *SearchTableConfig, table []byte, mask uint32
 		present := table[(h&mask)>>3]&(1<<((h&mask)&7)) != 0
 		if first {
 			firstPresent = present
-			// For a boundary match via overlap, at most matchLen-1+i pattern
-			// bytes are in block N. Continuation windows with prefix bytes in
-			// block N can't be verified against block N+1's table.
-			safeThreshold = ml + i
 			first = false
 			continue
 		}
 		if !present {
-			if i >= safeThreshold {
-				absent = append(absent, h)
-			} else {
-				// A "near" window is absent — the match can't be at K > overlap
-				// range (otherwise this window would be within block N and present).
-				nearAbsent = true
-			}
+			absent = append(absent, h)
 		}
 	}
 	if len(absent) == 0 {
 		return nil
 	}
 	if firstPresent {
-		// Only defer if a near window confirms K ≤ overlap range.
-		// If all near windows are present, K could exceed the overlap range
-		// and the far windows' prefix bytes could be at the block boundary.
-		if !nearAbsent {
-			return nil
-		}
 		return absent
 	}
-	// Raw fallback: first prefix window absent, check raw hash.
+	// First prefix window absent: a match is only possible anchored via the raw
+	// window (the leading prefix byte lies in the previous block).
 	hRaw := hashValue(readLE64Pad(pattern[:ml]), cfg.baseTableSize, cfg.matchLen)
 	if table[(hRaw&mask)>>3]&(1<<((hRaw&mask)&7)) != 0 {
 		return absent
 	}
-	return nil // raw fallback also absent → definite skip
+	return nil
 }
 
 // checkDeferredHashes checks if ALL deferred hashes are present in a table.

--- a/search_reader.go
+++ b/search_reader.go
@@ -29,6 +29,7 @@ type SearchStats struct {
 	BlocksDeferred        int     // Blocks that entered the deferred path
 	BlocksDeferredSkipped int     // Deferred blocks ultimately skipped (subset of BlocksSkipped)
 	BlocksFalsePositive   int     // Blocks decoded due to table match but containing no actual matches
+	BlocksBoundaryScanned int     // Blocks the table proved free of the pattern but decoded anyway, to rule out a match straddling in from the previous block (subset of BlocksSearched). A high count means boundary checks are forcing scans that the tables alone would have skipped.
 	TablePopMin           float64 // Min population % across tables seen
 	TablePopMax           float64 // Max population % across tables seen
 	TablePopSum           float64 // Sum of population % (for computing average)
@@ -55,6 +56,26 @@ type SearchStats struct {
 	CompressedBytesRLE          int64
 	CompressedBytesSparse       int64
 	CompressedBytesTableHeaders int64 // bytes consumed by serialized tables
+
+	// Windows holds per-pattern-window table-presence counts, populated when
+	// stats collection is enabled. Each entry is one matchLen-window the
+	// searcher tests against every block's table; Present/Absent count the
+	// tables whose bitmap had that window's hash set/clear. Rendered by
+	// FprintExtended — useful for seeing how selective the chosen matchLen and
+	// prefix are for a given pattern (the first prefix window is the skip gate).
+	Windows []WindowStat
+}
+
+// WindowStat reports, across every per-block search table, how often one
+// pattern window's hash bit was set ("present", block might contain it) or
+// clear ("absent", block definitely lacks it).
+type WindowStat struct {
+	Pos        int    // start index of the window within the pattern
+	Prefix     int    // pattern index of the preceding prefix byte; -1 = raw / no-prefix anchor
+	PrefixByte byte   // the prefix byte (0 when Prefix < 0)
+	Bytes      []byte // the matchLen bytes that get hashed
+	Present    int    // tables with the bit set
+	Absent     int    // tables with the bit clear
 }
 
 // Fprint writes a human-readable summary of the search stats to w.
@@ -71,6 +92,10 @@ func (st SearchStats) Fprint(w io.Writer) {
 	fmt.Fprintf(w, "Blocks searched: %d (%.1f%%), false positive: %d (%.1f%%)\n",
 		st.BlocksSearched, pct(st.BlocksSearched, total),
 		st.BlocksFalsePositive, pct(st.BlocksFalsePositive, searched))
+	if st.BlocksBoundaryScanned > 0 {
+		fmt.Fprintf(w, "Blocks boundary-scanned: %d (%.1f%% of searched) — table-absent but decoded to rule out a prev-block straddle\n",
+			st.BlocksBoundaryScanned, pct(st.BlocksBoundaryScanned, searched))
+	}
 	fmt.Fprintf(w, "Bytes skipped: %d compressed, searched: %d uncompressed\n", st.CompBytesSkipped, st.UncompBytesSearched)
 	fmt.Fprintf(w, "Tables: %d present, %d missing, %d unusable\n", st.TablesPresent, st.TablesMissing, st.TablesUnusable)
 	if st.TablesPresent > 0 {
@@ -108,6 +133,46 @@ func (st SearchStats) Fprint(w io.Writer) {
 			fmt.Fprintf(w, " Payload bytes: tabled=%d raw=%d RLE=%d sparse=%d; table-header bytes=%d\n",
 				st.CompressedBytesTabled, st.CompressedBytesRaw, st.CompressedBytesRLE, st.CompressedBytesSparse, st.CompressedBytesTableHeaders)
 		}
+	}
+}
+
+// FprintExtended writes the standard Fprint summary followed by a per-window
+// breakdown of how often each of the pattern's matchLen-windows was present in
+// the per-block tables. The first prefix window is the skip "gate"; the raw
+// fallback (prefix < 0) anchors a match whose prefix byte sits in the previous
+// block. Requires stats collection to have populated Windows.
+func (st SearchStats) FprintExtended(w io.Writer) {
+	st.Fprint(w)
+	if len(st.Windows) == 0 {
+		return
+	}
+	denom := st.Windows[0].Present + st.Windows[0].Absent
+	if denom == 0 {
+		denom = 1
+	}
+	// The raw-fallback role only applies to prefix tables (where a separate
+	// Prefix<0 window is appended); for no-prefix tables every window has
+	// Prefix<0 and is just a sequential position, so don't label those.
+	hasPrefixWindows := false
+	for _, ws := range st.Windows {
+		if ws.Prefix >= 0 {
+			hasPrefixWindows = true
+			break
+		}
+	}
+	fmt.Fprintf(w, "Pattern windows (per-hash presence across %d tables):\n", st.Windows[0].Present+st.Windows[0].Absent)
+	fmt.Fprintf(w, "  win  pat-pos  window           present            role\n")
+	for i, ws := range st.Windows {
+		role := ""
+		switch {
+		case i == 0:
+			role = "gate"
+		case ws.Prefix < 0 && hasPrefixWindows:
+			role = "raw fallback"
+		}
+		fmt.Fprintf(w, "  %-4d %-8d %-16q %7d (%5.1f%%)   %s\n",
+			i, ws.Pos, string(ws.Bytes),
+			ws.Present, 100*float64(ws.Present)/float64(denom), role)
 	}
 }
 
@@ -287,6 +352,11 @@ type BlockSearcher struct {
 	blockStart    int64
 	blockMatches  int // matches found in current block (for false positive tracking)
 	stats         SearchStats
+	// searchWindows is the pattern's matchLen-windows, enumerated once when the
+	// first usable table is seen; per-table presence is tallied into
+	// stats.Windows. Only populated under collectStats.
+	searchWindows []windowSpec
+	winInit       bool
 }
 
 // BlockSearchOption configures a BlockSearcher.
@@ -375,6 +445,7 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 	s.pending = nil
 	s.prevLazy = nil
 	s.tailBuf = s.tailBuf[:0]
+	s.winInit = false
 
 	if s.collectStats {
 		defer func() { s.stats.UncompressedSize = s.blockStart }()
@@ -479,6 +550,11 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 				}
 			}
 			if s.collectStats {
+				if !s.winInit {
+					s.searchWindows = s.stats.initWindows(&cfg, pattern)
+					s.winInit = true
+				}
+				s.stats.tallyWindows(s.searchWindows, cfg.baseTableSize, reductions, table)
 				s.stats.TablesPresent++
 				s.stats.TablesBytes += int64(chunkLen + 4) // +4 for chunk header
 				s.stats.TableBitsSum += int(cfg.baseTableSize - reductions)
@@ -547,6 +623,11 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 				}
 			}
 			if s.collectStats {
+				if !s.winInit {
+					s.searchWindows = s.stats.initWindows(&cfg, pattern)
+					s.winInit = true
+				}
+				s.stats.tallyWindows(s.searchWindows, cfg.baseTableSize, reductions, table)
 				s.stats.TablesPresent++
 				s.stats.TablesBytes += int64(chunkLen + 4)
 				s.stats.TablesCompressed++
@@ -728,6 +809,9 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 				s.stats.BlocksFalsePositive++
 			}
 			if tableNoMatch {
+				if s.collectStats {
+					s.stats.BlocksBoundaryScanned++
+				}
 				s.prevBlock = nil
 			} else {
 				s.prevBlock = blk
@@ -839,6 +923,9 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 				s.stats.BlocksFalsePositive++
 			}
 			if tableNoMatch {
+				if s.collectStats {
+					s.stats.BlocksBoundaryScanned++
+				}
 				s.prevBlock = nil
 			} else {
 				s.prevBlock = blk
@@ -1200,6 +1287,9 @@ func (s *BlockSearcher) resolvePending(pattern []byte, fn func(SearchResult) err
 		s.stats.BlocksFalsePositive++
 	}
 	if p.tableNoMatch {
+		if s.collectStats {
+			s.stats.BlocksBoundaryScanned++
+		}
 		s.prevBlock = nil
 	} else {
 		s.prevBlock = blk
@@ -1603,4 +1693,100 @@ func checkDeferredHashes(table []byte, reductions, baseTableSize uint8, hashes [
 		}
 	}
 	return true
+}
+
+// windowSpec is one matchLen-window the searcher tests for a pattern, with its
+// full-resolution (un-reduced) hash precomputed once (baseTableSize is constant
+// per stream).
+type windowSpec struct {
+	prefix int // pattern index of the prefix byte; -1 for the raw / no-prefix anchor
+	pos    int // pattern index where the window starts
+	hash   uint32
+}
+
+// enumeratePatternWindows returns, in pattern order, every matchLen-window the
+// searcher tests for pattern under cfg, mirroring patternCanMatch /
+// patternDeferHashes. For byte/mask prefix tables the raw fallback window (the
+// leading matchLen bytes, anchoring a match whose prefix byte sits in the
+// previous block) is appended last.
+func enumeratePatternWindows(cfg *SearchTableConfig, pattern []byte) []windowSpec {
+	ml := int(cfg.matchLen)
+	if ml == 0 || len(pattern) < ml {
+		return nil
+	}
+	var out []windowSpec
+	add := func(prefix, pos int) {
+		h := hashValue(readLE64Pad(pattern[pos:]), cfg.baseTableSize, cfg.matchLen)
+		out = append(out, windowSpec{prefix: prefix, pos: pos, hash: h})
+	}
+	switch cfg.tableType {
+	case searchTableTypeNoPrefix:
+		for i := 0; i <= len(pattern)-ml; i++ {
+			add(-1, i)
+		}
+	case searchTableTypeBytePrefix:
+		var pfx [256]bool
+		for _, p := range cfg.prefixBytes {
+			pfx[p] = true
+		}
+		for i := 1; i <= len(pattern)-ml; i++ {
+			if pfx[pattern[i-1]] {
+				add(i-1, i)
+			}
+		}
+		add(-1, 0)
+	case searchTableTypeMaskPrefix:
+		for i := 1; i <= len(pattern)-ml; i++ {
+			b := pattern[i-1]
+			if cfg.prefixMask[b>>3]&(1<<(b&7)) != 0 {
+				add(i-1, i)
+			}
+		}
+		add(-1, 0)
+	case searchTableTypeLongPrefix:
+		pl := len(cfg.longPrefix)
+		ex := int(cfg.extras)
+		for i := 0; i <= len(pattern)-pl-ml-ex; i++ {
+			if bytes.Equal(pattern[i:i+pl], cfg.longPrefix) {
+				for j := 0; j <= ex; j++ {
+					add(i, i+pl+j)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// initWindows enumerates pattern windows under cfg and seeds st.Windows with
+// their metadata, returning the specs for per-table tallying via tallyWindows.
+func (st *SearchStats) initWindows(cfg *SearchTableConfig, pattern []byte) []windowSpec {
+	windows := enumeratePatternWindows(cfg, pattern)
+	ml := int(cfg.matchLen)
+	st.Windows = make([]WindowStat, len(windows))
+	for i, wd := range windows {
+		ws := WindowStat{Pos: wd.pos, Prefix: wd.prefix}
+		ws.Bytes = append(ws.Bytes, pattern[wd.pos:min(wd.pos+ml, len(pattern))]...)
+		if wd.prefix >= 0 {
+			ws.PrefixByte = pattern[wd.prefix]
+		}
+		st.Windows[i] = ws
+	}
+	return windows
+}
+
+// tallyWindows updates per-window present/absent counts against one block's
+// table. baseTableSize must match the value used to compute windows' hashes.
+func (st *SearchStats) tallyWindows(windows []windowSpec, baseTableSize, reductions uint8, table []byte) {
+	if len(windows) == 0 || len(table) == 0 {
+		return
+	}
+	mask := uint32(1<<(baseTableSize-reductions)) - 1
+	for i := range windows {
+		h := windows[i].hash & mask
+		if table[h>>3]&(1<<(h&7)) != 0 {
+			st.Windows[i].Present++
+		} else {
+			st.Windows[i].Absent++
+		}
+	}
 }

--- a/search_reader.go
+++ b/search_reader.go
@@ -354,9 +354,12 @@ type BlockSearcher struct {
 	stats         SearchStats
 	// searchWindows is the pattern's matchLen-windows, enumerated once when the
 	// first usable table is seen; per-table presence is tallied into
-	// stats.Windows. Only populated under collectStats.
+	// stats.Windows. Only populated under collectStats. winCfg is the layout
+	// they were enumerated for; tallying stops if a later table's config differs
+	// (mixing layouts would mislabel the counts).
 	searchWindows []windowSpec
 	winInit       bool
+	winCfg        SearchTableConfig
 }
 
 // BlockSearchOption configures a BlockSearcher.
@@ -495,10 +498,20 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 			if blockSize > maxBlockSize {
 				return ErrCorrupt
 			}
+			// A concatenated stream starts here. Flush any pending forward-context
+			// dispatch and drop per-stream boundary state so matches and offsets
+			// don't straddle into the new stream (which restarts at offset 0).
+			if s.deferred != nil {
+				if err := s.flushDeferred(nil, fn); err != nil {
+					return err
+				}
+			}
 			s.maxBlock = blockSize
 			s.blockStart = 0
 			s.pending = nil
+			s.prevBlock = nil
 			s.prevLazy = nil
+			s.tailBuf = s.tailBuf[:0]
 			s.blockTable = nil
 			s.blockTableUnusable = false
 			continue
@@ -551,8 +564,11 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 			}
 			if s.collectStats {
 				if !s.winInit {
+					s.winCfg = cfg
 					s.searchWindows = s.stats.initWindows(&cfg, pattern)
 					s.winInit = true
+				} else if s.searchWindows != nil && !sameSearchLayout(&s.winCfg, &cfg) {
+					s.searchWindows = nil // config drift: stop, mixed layouts would mislabel
 				}
 				s.stats.tallyWindows(s.searchWindows, cfg.baseTableSize, reductions, table)
 				s.stats.TablesPresent++
@@ -624,8 +640,11 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 			}
 			if s.collectStats {
 				if !s.winInit {
+					s.winCfg = cfg
 					s.searchWindows = s.stats.initWindows(&cfg, pattern)
 					s.winInit = true
+				} else if s.searchWindows != nil && !sameSearchLayout(&s.winCfg, &cfg) {
+					s.searchWindows = nil // config drift: stop, mixed layouts would mislabel
 				}
 				s.stats.tallyWindows(s.searchWindows, cfg.baseTableSize, reductions, table)
 				s.stats.TablesPresent++
@@ -1789,4 +1808,24 @@ func (st *SearchStats) tallyWindows(windows []windowSpec, baseTableSize, reducti
 			st.Windows[i].Absent++
 		}
 	}
+}
+
+// sameSearchLayout reports whether two configs produce the same per-window
+// layout (and hashes), i.e. whether their tables can be tallied into the same
+// SearchStats.Windows. matchLen, baseTableSize and the prefix all affect the
+// enumerated windows; per-block reductions do not (they only mask at lookup).
+func sameSearchLayout(a, b *SearchTableConfig) bool {
+	if a.tableType != b.tableType || a.matchLen != b.matchLen ||
+		a.baseTableSize != b.baseTableSize || a.extras != b.extras {
+		return false
+	}
+	switch a.tableType {
+	case searchTableTypeBytePrefix:
+		return a.prefixBytes == b.prefixBytes
+	case searchTableTypeMaskPrefix:
+		return a.prefixMask == b.prefixMask
+	case searchTableTypeLongPrefix:
+		return bytes.Equal(a.longPrefix, b.longPrefix)
+	}
+	return true
 }

--- a/search_table.go
+++ b/search_table.go
@@ -258,10 +258,17 @@ func (c *SearchTableConfig) maxChunkSize() int {
 
 // overlapBytes returns the number of bytes the search-table encoder needs
 // from the start of the next block to safely index positions near the end
-// of the current block. With extras=E (type 4), the encoder reads up to
-// matchLen+E-1 bytes past the block end.
+// of the current block. An occurrence is indexed in the block where its prefix
+// starts (SPEC_SEARCH.md 2.1), so the encoder reads the window(s) — and, for a
+// long prefix that starts in this block but straddles into the next, the rest
+// of the prefix — from the overlap: matchLen+extras bytes, plus len(prefix)-1
+// for a long prefix.
 func (c *SearchTableConfig) overlapBytes() int {
-	return max(0, int(c.matchLen)+int(c.extras)-1)
+	n := int(c.matchLen) + int(c.extras)
+	if c.tableType == searchTableTypeLongPrefix {
+		n += len(c.longPrefix) - 1
+	}
+	return max(0, n)
 }
 
 func (c *SearchTableConfig) prefixSize() int {

--- a/search_test.go
+++ b/search_test.go
@@ -6,11 +6,39 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/minio/minlz/internal/reference"
 )
+
+// loadTomSawyer returns the Tom Sawyer sample corpus.
+func loadTomSawyer(t testing.TB) []byte {
+	t.Helper()
+	b, err := os.ReadFile("testdata/Mark.Twain-Tom.Sawyer.txt")
+	if err != nil {
+		t.Fatalf("read testdata: %v", err)
+	}
+	return b
+}
+
+// tomSawyerCorpus builds a multi-block corpus by concatenating `copies`
+// rotations of the Tom Sawyer sample. Rotating each copy by a different byte
+// offset keeps every byte of text (so natural patterns stay searchable) while
+// shifting the content against the block grid, so block-boundary straddles are
+// exercised at many positions and no two copies are byte-identical. (A byte
+// XOR/offset transform would scramble the text and defeat both properties.)
+func tomSawyerCorpus(t testing.TB, copies int) []byte {
+	base := loadTomSawyer(t)
+	out := make([]byte, 0, copies*len(base))
+	for k := 0; k < copies; k++ {
+		off := (k * 257) % len(base)
+		out = append(out, base[off:]...)
+		out = append(out, base[:off]...)
+	}
+	return out
+}
 
 // withBaseTableSize sets baseTableSize directly for unit testing.
 func withBaseTableSize(c SearchTableConfig, ts int) SearchTableConfig {
@@ -2331,14 +2359,53 @@ func FuzzSearchRoundtrip(f *testing.F) {
 			return
 		}
 		cfg := NewSearchTableConfig().WithMatchLen(matchLen)
+		// usePrefix picks a prefix table; a second input bit selects a long
+		// (multi-byte) prefix when the pattern is long enough, so the fuzzer
+		// exercises the long-prefix boundary-straddle path too.
+		useLong := false
 		if usePrefix && len(pattern) > 0 {
-			cfg = cfg.WithBytePrefix(pattern[0])
+			if len(data) > 1 && data[1]&1 == 1 && len(pattern) >= 2+matchLen {
+				cfg = cfg.WithLongPrefix(pattern[:2])
+				useLong = true
+			} else {
+				cfg = cfg.WithBytePrefix(pattern[0])
+			}
 		}
 
+		// Exercise every writer mode and concurrency. The mode is keyed off the
+		// input (the corpus signature is fixed) so the coverage-guided fuzzer
+		// explores each branch — these are the paths that hid the streaming and
+		// concurrent-search bugs.
+		mode := data[0]
+		cpu := 1
+		if mode&1 != 0 {
+			cpu = 4
+		}
 		var buf bytes.Buffer
-		w := NewWriter(&buf, WriterSearchTable(cfg), WriterBlockSize(minBlockSize), WriterConcurrency(1))
-		_, err := w.Write(data)
-		if err != nil {
+		w := NewWriter(&buf, WriterSearchTable(cfg), WriterBlockSize(minBlockSize), WriterConcurrency(cpu))
+		var werr error
+		switch (mode >> 1) % 5 {
+		case 0:
+			werr = w.EncodeBuffer(append([]byte(nil), data...))
+		case 1:
+			_, werr = w.Write(data)
+		case 2: // block-aligned streaming writes
+			for i := 0; i < len(data) && werr == nil; i += minBlockSize {
+				_, werr = w.Write(data[i:min(i+minBlockSize, len(data))])
+			}
+		case 3: // odd-sized streaming writes
+			for i := 0; i < len(data) && werr == nil; i += 333 {
+				_, werr = w.Write(data[i:min(i+333, len(data))])
+			}
+		case 4: // write, mid-stream Flush, write
+			mid := len(data) / 2
+			if _, werr = w.Write(data[:mid]); werr == nil {
+				if werr = w.Flush(); werr == nil {
+					_, werr = w.Write(data[mid:])
+				}
+			}
+		}
+		if werr != nil {
 			return // some data may cause issues
 		}
 		if err := w.Close(); err != nil {
@@ -2356,7 +2423,21 @@ func FuzzSearchRoundtrip(f *testing.F) {
 
 		// Collect all expected match offsets from the original data.
 		var expected []int64
-		if usePrefix {
+		if useLong {
+			// Long prefix: count occurrences preceded by the long prefix
+			// (conservative subset that must always be found).
+			lp := pattern[:2]
+			needle := append(append([]byte{}, lp...), pattern...)
+			off := 0
+			for {
+				idx := bytes.Index(data[off:], needle)
+				if idx < 0 {
+					break
+				}
+				expected = append(expected, int64(off+idx+len(lp)))
+				off += idx + 1
+			}
+		} else if usePrefix {
 			// For prefix tables, only count occurrences preceded by the prefix byte.
 			pfx := pattern[0]
 			needle := append([]byte{pfx}, pattern...)
@@ -3726,5 +3807,435 @@ func TestExtrasBoundaryOverlap(t *testing.T) {
 	}
 	if found == 0 {
 		t.Fatalf("boundary-straddling needle not found; stats: %+v", searcher.Stats())
+	}
+}
+
+// TestSearchConcurrentStreamingRoundtrip guards a buffer-truncation bug in the
+// concurrent writer's search-table assembly (writer.go): a small/partial final
+// block whose compressed chunk exceeded len(uncompressed)+obufHeaderLen-smc had
+// its data copy truncated, corrupting the stream. Exercises Concurrency>1 +
+// streaming Write (block-by-block) + search — a combination the other tests miss.
+func TestSearchConcurrentStreamingRoundtrip(t *testing.T) {
+	for _, copies := range []int{1, 3, 12} {
+		data := tomSawyerCorpus(t, copies)
+		for _, cpu := range []int{2, 4} {
+			var buf bytes.Buffer
+			cfg := NewSearchTableConfig().WithMatchLen(6).WithBytePrefix(' ')
+			w := NewWriter(&buf, WriterSearchTable(cfg), WriterBlockSize(minBlockSize), WriterConcurrency(cpu))
+			for i := 0; i < len(data); i += minBlockSize {
+				end := min(i+minBlockSize, len(data))
+				if _, err := w.Write(data[i:end]); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := w.Close(); err != nil {
+				t.Fatal(err)
+			}
+			dec, err := io.ReadAll(NewReader(bytes.NewReader(buf.Bytes())))
+			if err != nil {
+				t.Fatalf("copies=%d cpu=%d: decode failed: %v", copies, cpu, err)
+			}
+			if !bytes.Equal(dec, data) {
+				t.Fatalf("copies=%d cpu=%d: roundtrip mismatch (got %d want %d)", copies, cpu, len(dec), len(data))
+			}
+		}
+	}
+}
+
+// TestSearchLongPrefixStraddle guards the encoder fix for a multi-byte prefix
+// that itself straddles a block boundary: the occurrence is indexed in the block
+// where its prefix STARTS (reading the prefix tail + window from the overlap),
+// so the match is still found. Covers extras = 0 and extras > 0.
+func TestSearchLongPrefixStraddle(t *testing.T) {
+	for _, extras := range []int{0, 3} {
+		bs := minBlockSize
+		prefix := []byte("<<>")
+		ml := 4
+		filler := bytes.Repeat([]byte("the quick brown fox\n"), bs/20+2)
+		// Place the 3-byte prefix straddling the block-0/block-1 boundary:
+		// "<<" at the end of block 0, ">" + value at the start of block 1.
+		data := make([]byte, 0, bs*2)
+		data = append(data, filler[:bs-2]...)
+		data = append(data, '<', '<')              // block0[bs-2], block0[bs-1]
+		data = append(data, '>')                   // block1[0] -> prefix "<<>" straddles
+		data = append(data, []byte("NEEDLExyzabc")...)
+		data = append(data, filler...)
+		needle := append(append([]byte{}, prefix...), []byte("NEEDLE")...)
+		if bytes.Count(data, needle) != 1 {
+			t.Fatalf("extras=%d setup count=%d", extras, bytes.Count(data, needle))
+		}
+
+		var buf bytes.Buffer
+		cfg := NewSearchTableConfig().WithMatchLen(ml).WithLongPrefix(prefix).WithExtras(extras)
+		w := NewWriter(&buf, WriterSearchTable(cfg), WriterBlockSize(bs), WriterConcurrency(1))
+		if err := w.EncodeBuffer(append([]byte(nil), data...)); err != nil {
+			t.Fatalf("extras=%d: %v", extras, err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("extras=%d: %v", extras, err)
+		}
+		found := 0
+		if err := NewBlockSearcher(bytes.NewReader(buf.Bytes())).Search(needle, func(r SearchResult) error {
+			found++
+			return nil
+		}); err != nil {
+			t.Fatalf("extras=%d: %v", extras, err)
+		}
+		if found != 1 {
+			t.Errorf("extras=%d: long-prefix straddling-prefix match missed (found=%d)", extras, found)
+		}
+	}
+}
+
+// TestSearchLongPrefixNoFalseNegatives encodes a multi-block corpus with a long
+// prefix and verifies every occurrence of needles beginning with that prefix is
+// found, across encode methods and concurrency.
+func TestSearchLongPrefixNoFalseNegatives(t *testing.T) {
+	data := tomSawyerCorpus(t, 16)
+	prefix := []byte("the ")
+	needles := []string{"the adventures", "the boys", "the fence", "the river", "the cave"}
+	for _, cpu := range []int{1, 4} {
+		for _, stream := range []bool{false, true} {
+			var buf bytes.Buffer
+			cfg := NewSearchTableConfig().WithMatchLen(6).WithLongPrefix(prefix)
+			w := NewWriter(&buf, WriterSearchTable(cfg), WriterBlockSize(minBlockSize), WriterConcurrency(cpu))
+			if stream {
+				for i := 0; i < len(data); i += 1024 {
+					w.Write(data[i:min(i+1024, len(data))])
+				}
+			} else if err := w.EncodeBuffer(append([]byte(nil), data...)); err != nil {
+				t.Fatal(err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatal(err)
+			}
+			s := buf.Bytes()
+			for _, ns := range needles {
+				pat := []byte(ns)
+				want := map[int64]bool{}
+				for off := 0; ; {
+					i := bytes.Index(data[off:], pat)
+					if i < 0 {
+						break
+					}
+					want[int64(off+i)] = true
+					off += i + 1
+				}
+				got := map[int64]bool{}
+				if err := NewBlockSearcher(bytes.NewReader(s)).Search(pat, func(r SearchResult) error {
+					got[r.StreamOffset] = true
+					return nil
+				}); err != nil {
+					t.Fatalf("cpu%d stream=%v %q: %v", cpu, stream, ns, err)
+				}
+				for off := range want {
+					if !got[off] {
+						t.Errorf("cpu%d stream=%v %q: missing occurrence at %d (want %d, got %d)", cpu, stream, ns, off, len(want), len(got))
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestSearchStreamingForwardStraddle guards the deferred-overlap fix: streaming
+// Write must not emit a non-last block without its forward overlap, or a match
+// straddling that boundary would be missed. The held block is emitted with
+// overlap once the next Write arrives.
+func TestSearchStreamingForwardStraddle(t *testing.T) {
+	for _, cpu := range []int{1, 2, 4} {
+		bs := minBlockSize
+		filler := bytes.Repeat([]byte("the quick brown fox jumps over\n"), bs/31+2)
+		first := make([]byte, bs)
+		copy(first, filler)
+		first[bs-1] = ' ' // last byte of block 0 is the prefix byte
+		pat := []byte(" zqxjvkmarker9")
+		second := append(append([]byte{}, pat[1:]...), filler...)
+
+		var buf bytes.Buffer
+		cfg := NewSearchTableConfig().WithMatchLen(6).WithBytePrefix(' ')
+		w := NewWriter(&buf, WriterSearchTable(cfg), WriterBlockSize(bs), WriterConcurrency(cpu))
+		if _, err := w.Write(first); err != nil { // held (deferred)
+			t.Fatal(err)
+		}
+		if _, err := w.Write(second); err != nil { // supplies block 0's overlap
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		full := append(append([]byte{}, first...), second...)
+		if bytes.Count(full, pat) != 1 {
+			t.Fatalf("cpu%d: setup count=%d", cpu, bytes.Count(full, pat))
+		}
+		found := 0
+		if err := NewBlockSearcher(bytes.NewReader(buf.Bytes())).Search(pat, func(r SearchResult) error {
+			found++
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if found != 1 {
+			t.Errorf("cpu%d: straddling match across a streaming block boundary was missed (found=%d)", cpu, found)
+		}
+	}
+}
+
+// TestSearchEncodeMethodsNoFalseNegatives runs the same corpus through every
+// encode path (EncodeBuffer, streaming Write at several chunk sizes, ReadFrom)
+// at Concurrency 1 and 4, and verifies the searcher reports exactly the true
+// occurrences of each pattern — no false negatives, no corruption.
+func TestSearchEncodeMethodsNoFalseNegatives(t *testing.T) {
+	data := tomSawyerCorpus(t, 12)
+	cfg := NewSearchTableConfig().WithMatchLen(6).WithBytePrefix(' ', '\n')
+	patterns := []string{" the ", " Tom Sawyer", " whitewash", "\nCHAPTER", " graveyard at"}
+	gt := func(pat []byte) map[int64]bool {
+		m := map[int64]bool{}
+		for off := 0; ; {
+			i := bytes.Index(data[off:], pat)
+			if i < 0 {
+				break
+			}
+			m[int64(off+i)] = true
+			off += i + 1
+		}
+		return m
+	}
+	encode := func(method string, cpu int) []byte {
+		var buf bytes.Buffer
+		w := NewWriter(&buf, WriterSearchTable(cfg), WriterBlockSize(minBlockSize), WriterConcurrency(cpu))
+		switch method {
+		case "EncodeBuffer":
+			if err := w.EncodeBuffer(append([]byte(nil), data...)); err != nil {
+				t.Fatal(err)
+			}
+		case "Write-1":
+			for i := range data {
+				w.Write(data[i : i+1])
+			}
+		case "Write-block":
+			for i := 0; i < len(data); i += minBlockSize {
+				w.Write(data[i:min(i+minBlockSize, len(data))])
+			}
+		case "Write-odd":
+			for i := 0; i < len(data); i += 997 {
+				w.Write(data[i:min(i+997, len(data))])
+			}
+		case "ReadFrom":
+			w.ReadFrom(bytes.NewReader(data))
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return buf.Bytes()
+	}
+	for _, method := range []string{"EncodeBuffer", "Write-1", "Write-block", "Write-odd", "ReadFrom"} {
+		for _, cpu := range []int{1, 4} {
+			stream := encode(method, cpu)
+			dec, err := io.ReadAll(NewReader(bytes.NewReader(stream)))
+			if err != nil || !bytes.Equal(dec, data) {
+				t.Errorf("%s/cpu%d: roundtrip failed (err=%v)", method, cpu, err)
+				continue
+			}
+			for _, ps := range patterns {
+				pat := []byte(ps)
+				want := gt(pat)
+				got := map[int64]bool{}
+				if err := NewBlockSearcher(bytes.NewReader(stream)).Search(pat, func(r SearchResult) error {
+					got[r.StreamOffset] = true
+					return nil
+				}); err != nil {
+					t.Errorf("%s/cpu%d %q: %v", method, cpu, ps, err)
+					continue
+				}
+				if len(got) != len(want) {
+					t.Errorf("%s/cpu%d %q: found %d occurrences, want %d", method, cpu, ps, len(got), len(want))
+				}
+			}
+		}
+	}
+}
+
+// TestSearchPrefixDeferralSkipsRealData is the regression guard for the prefix
+// deferral fix. The searcher's "might match" decision keys only off the FIRST
+// prefix-context window; the discriminating windows are used via the deferred
+// path. The sentinel begins with a common word, so its first window (" the") is
+// present in (nearly) every block — before the fix the deferred path bailed and
+// ~0 blocks were skipped. The unique remainder must now skip the blocks that
+// don't contain it.
+func TestSearchPrefixDeferralSkipsRealData(t *testing.T) {
+	data := tomSawyerCorpus(t, 32) // ~450 KB
+	sentinel := []byte(" the qzxjvk wbnmfp ldghqr zpopuli")
+	copy(data[len(data)/2:], sentinel)
+	if c := bytes.Count(data, sentinel); c != 1 {
+		t.Fatalf("sentinel not unique (count=%d)", c)
+	}
+
+	var buf bytes.Buffer
+	cfg := NewSearchTableConfig().WithMatchLen(4).WithBytePrefix(' ')
+	w := NewWriter(&buf, WriterSearchTable(cfg), WriterBlockSize(minBlockSize), WriterConcurrency(1))
+	if err := w.EncodeBuffer(append([]byte(nil), data...)); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	searcher := NewBlockSearcher(bytes.NewReader(buf.Bytes()), BlockSearchCollectStats())
+	var found []int64
+	if err := searcher.Search(sentinel, func(r SearchResult) error {
+		found = append(found, r.StreamOffset)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	st := searcher.Stats()
+	t.Logf("blocks total=%d skipped=%d searched=%d deferred=%d falsePos=%d missing=%d",
+		st.BlocksTotal, st.BlocksSkipped, st.BlocksSearched, st.BlocksDeferred, st.BlocksFalsePositive, st.TablesMissing)
+
+	if len(found) != 1 || found[0] != int64(len(data)/2) {
+		t.Fatalf("expected one match at %d, got %v", len(data)/2, found)
+	}
+	// Before the fix this was ~0. The discriminating windows must skip most blocks.
+	if st.BlocksSkipped < st.BlocksTotal/2 {
+		t.Errorf("prefix deferral ineffective: skipped %d/%d blocks", st.BlocksSkipped, st.BlocksTotal)
+	}
+}
+
+// TestSearchPrefixNoFalseNegativesRealData encodes a multi-block, byte-shifted
+// Tom Sawyer corpus with prefix tables and verifies the searcher reports exactly
+// the true occurrences of several patterns — exercising deferral and the
+// block-boundary path across many alignments with no false negatives.
+func TestSearchPrefixNoFalseNegativesRealData(t *testing.T) {
+	data := tomSawyerCorpus(t, 64) // ~900 KB, ~220 blocks
+	var buf bytes.Buffer
+	cfg := NewSearchTableConfig().WithMatchLen(6).WithBytePrefix(' ', '\n', '.', ',')
+	w := NewWriter(&buf, WriterSearchTable(cfg), WriterBlockSize(minBlockSize), WriterConcurrency(1))
+	if err := w.EncodeBuffer(append([]byte(nil), data...)); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	stream := buf.Bytes()
+
+	patterns := []string{
+		" the ", " Tom Sawyer", " whitewash", "\nCHAPTER", " said the", " graveyard at",
+	}
+	for _, ps := range patterns {
+		pat := []byte(ps)
+		want := map[int64]bool{}
+		for off := 0; ; {
+			i := bytes.Index(data[off:], pat)
+			if i < 0 {
+				break
+			}
+			want[int64(off+i)] = true
+			off += i + 1
+		}
+		searcher := NewBlockSearcher(bytes.NewReader(stream))
+		got := map[int64]bool{}
+		if err := searcher.Search(pat, func(r SearchResult) error {
+			got[r.StreamOffset] = true
+			return nil
+		}); err != nil {
+			t.Fatalf("%q: %v", ps, err)
+		}
+		if len(got) != len(want) {
+			t.Errorf("%q: found %d occurrences, want %d", ps, len(got), len(want))
+		}
+		for off := range want {
+			if !got[off] {
+				t.Errorf("%q: missing occurrence at stream offset %d", ps, off)
+			}
+		}
+	}
+}
+
+// TestSearchPrefixBoundaryWindowIndexed verifies the encoder records the
+// boundary window — the prefix-context window whose prefix byte is the block's
+// LAST byte (its value begins in the next block). Block N+1 cannot index it, so
+// block N records it from the overlap (SPEC_SEARCH.md 3.3.1, B.1).
+func TestSearchPrefixBoundaryWindowIndexed(t *testing.T) {
+	var mask [32]byte
+	mask['"'>>3] |= 1 << ('"' & 7)
+	cfg := withBaseTableSize(NewSearchTableConfig().WithMatchLen(8).WithMaskPrefix(mask), 16)
+	cfg.maxReducedPopPct = 0
+	ml := int(cfg.matchLen)
+
+	// P[:8] ends block N; P[8:] starts N+1. P[7]='"' makes offset-8 a prefix
+	// window whose prefix byte is N's last byte (the boundary window).
+	P := []byte(`"AAAAAA"CDEFGHIJ"KLMNOPQR`)
+	N := append(bytes.Repeat([]byte("x"), 56), P[:8]...)
+	N1 := append(append([]byte{}, P[8:]...), bytes.Repeat([]byte("y"), 32)...)
+	boundary := P[8:16] // "CDEFGHIJ"
+
+	has := func(table []byte, red uint8, w []byte) bool {
+		m := uint32(1<<(cfg.baseTableSize-red)) - 1
+		h := hashValue(readLE64Pad(w), cfg.baseTableSize, cfg.matchLen) & m
+		return table[h>>3]&(1<<(h&7)) != 0
+	}
+
+	if cfg.overlapBytes() < ml {
+		t.Fatalf("overlapBytes()=%d, want >= matchLen=%d", cfg.overlapBytes(), ml)
+	}
+	tN, redN := cfg.buildSearchTable(N, N1[:cfg.overlapBytes()], nil, false)
+	if !has(tN, redN, boundary) {
+		t.Error("boundary window not recorded in block N with full overlap")
+	}
+	tN1, redN1 := cfg.buildSearchTable(N1, nil, nil, false)
+	if has(tN1, redN1, boundary) {
+		t.Error("boundary window unexpectedly recorded in block N+1")
+	}
+}
+
+// TestSearchFlushOmitsTable verifies that a mid-stream Flush emits its block
+// without a search table (no forward overlap is available), so the block is
+// always scanned and a match straddling the flush boundary is still found,
+// while Close keeps the stream-final block's table.
+func TestSearchFlushOmitsTable(t *testing.T) {
+	bs := minBlockSize
+	cfg := NewSearchTableConfig().WithMatchLen(6).WithBytePrefix(' ')
+	filler := bytes.Repeat([]byte("the quick brown fox jumps\n"), bs/26+2)
+	pat := []byte(" zqxjvkmarker9")
+
+	first := make([]byte, bs)
+	copy(first, filler)
+	first[bs-1] = ' ' // last byte of the flushed block is the prefix byte
+
+	var buf bytes.Buffer
+	w := NewWriter(&buf, WriterSearchTable(cfg), WriterBlockSize(bs), WriterConcurrency(1))
+	if _, err := w.Write(first); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Flush(); err != nil { // flushes block 0 WITHOUT a table
+		t.Fatal(err)
+	}
+	if _, err := w.Write(pat[1:]); err != nil { // continuation of the straddle
+		t.Fatal(err)
+	}
+	if _, err := w.Write(filler); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	full := append(append(append([]byte{}, first...), pat[1:]...), filler...)
+	if c := bytes.Count(full, pat); c != 1 {
+		t.Fatalf("setup: pattern count = %d", c)
+	}
+
+	searcher := NewBlockSearcher(bytes.NewReader(buf.Bytes()), BlockSearchCollectStats())
+	found := 0
+	if err := searcher.Search(pat, func(r SearchResult) error { found++; return nil }); err != nil {
+		t.Fatal(err)
+	}
+	st := searcher.Stats()
+	if found != 1 {
+		t.Errorf("straddle across flush boundary missed (found=%d); stats %+v", found, st)
+	}
+	if st.TablesMissing == 0 {
+		t.Errorf("expected the flushed block to carry no table (TablesMissing>0), got %d", st.TablesMissing)
 	}
 }

--- a/search_test.go
+++ b/search_test.go
@@ -2381,31 +2381,45 @@ func FuzzSearchRoundtrip(f *testing.F) {
 		if mode&1 != 0 {
 			cpu = 4
 		}
-		var buf bytes.Buffer
-		w := NewWriter(&buf, WriterSearchTable(cfg), WriterBlockSize(minBlockSize), WriterConcurrency(cpu))
-		var werr error
-		switch (mode >> 1) % 5 {
-		case 0:
-			werr = w.EncodeBuffer(append([]byte(nil), data...))
-		case 1:
-			_, werr = w.Write(data)
-		case 2: // block-aligned streaming writes
-			for i := 0; i < len(data) && werr == nil; i += minBlockSize {
-				_, werr = w.Write(data[i:min(i+minBlockSize, len(data))])
-			}
-		case 3: // odd-sized streaming writes
-			for i := 0; i < len(data) && werr == nil; i += 333 {
-				_, werr = w.Write(data[i:min(i+333, len(data))])
-			}
-		case 4: // write, mid-stream Flush, write
-			mid := len(data) / 2
-			if _, werr = w.Write(data[:mid]); werr == nil {
-				if werr = w.Flush(); werr == nil {
-					_, werr = w.Write(data[mid:])
+		// writeMode replays the selected writer mode onto w. Shared so the same
+		// mode drives both the inline stream and the sidecar stream below.
+		writeMode := func(w *Writer) error {
+			switch (mode >> 1) % 5 {
+			case 0:
+				return w.EncodeBuffer(append([]byte(nil), data...))
+			case 1:
+				_, err := w.Write(data)
+				return err
+			case 2: // block-aligned streaming writes
+				for i := 0; i < len(data); i += minBlockSize {
+					if _, err := w.Write(data[i:min(i+minBlockSize, len(data))]); err != nil {
+						return err
+					}
 				}
+				return nil
+			case 3: // odd-sized streaming writes
+				for i := 0; i < len(data); i += 333 {
+					if _, err := w.Write(data[i:min(i+333, len(data))]); err != nil {
+						return err
+					}
+				}
+				return nil
+			default: // 4: write, mid-stream Flush, write
+				mid := len(data) / 2
+				if _, err := w.Write(data[:mid]); err != nil {
+					return err
+				}
+				if err := w.Flush(); err != nil {
+					return err
+				}
+				_, err := w.Write(data[mid:])
+				return err
 			}
 		}
-		if werr != nil {
+
+		var buf bytes.Buffer
+		w := NewWriter(&buf, WriterSearchTable(cfg), WriterBlockSize(minBlockSize), WriterConcurrency(cpu))
+		if werr := writeMode(w); werr != nil {
 			return // some data may cause issues
 		}
 		if err := w.Close(); err != nil {
@@ -2494,6 +2508,51 @@ func FuzzSearchRoundtrip(f *testing.F) {
 			for i := 1; i < len(found); i++ {
 				if found[i] <= found[i-1] {
 					t.Fatalf("found offsets not in order: [%d]=%d <= [%d]=%d",
+						i, found[i], i-1, found[i-1])
+				}
+			}
+		}
+
+		// Sidecar path: same data/pattern/mode, but the search tables live in a
+		// separate stream and the searcher decodes blocks in coalesced batches.
+		// That gives it a distinct skip/defer/boundary path, so it must
+		// independently find every match and the main stream must still decode.
+		var main, side bytes.Buffer
+		ws := NewWriter(&main, WriterSearchTable(cfg), WriterBlockSize(minBlockSize), WriterConcurrency(cpu), WriterSidecar(&side))
+		if werr := writeMode(ws); werr != nil {
+			t.Fatalf("sidecar write failed (mode %d, inline succeeded): %v", (mode>>1)%5, werr)
+		}
+		if err := ws.Close(); err != nil {
+			t.Fatalf("sidecar close failed: %v", err)
+		}
+		if dec, derr := io.ReadAll(NewReader(bytes.NewReader(main.Bytes()))); derr != nil || !bytes.Equal(dec, data) {
+			t.Fatalf("sidecar main stream not decodable/equal: err=%v", derr)
+		}
+		if len(expected) > 0 {
+			ss := NewSidecarSearcher(bytes.NewReader(main.Bytes()), bytes.NewReader(side.Bytes()), BlockSearchCollectStats())
+			var found []int64
+			if serr := ss.Search(pattern, func(r SearchResult) error {
+				found = append(found, r.StreamOffset)
+				return nil
+			}); serr != nil {
+				t.Fatalf("sidecar search failed: %v", serr)
+			}
+			foundSet := make(map[int64]bool, len(found))
+			for _, fo := range found {
+				foundSet[fo] = true
+			}
+			for _, e := range expected {
+				if !foundSet[e] {
+					st := ss.Stats()
+					t.Fatalf("sidecar: expected match at offset %d not found (prefix=%v, expected=%d found=%d). "+
+						"blocks: total=%d skipped=%d searched=%d boundary=%d",
+						e, usePrefix, len(expected), len(found),
+						st.BlocksTotal, st.BlocksSkipped, st.BlocksSearched, st.BlocksBoundaryScanned)
+				}
+			}
+			for i := 1; i < len(found); i++ {
+				if found[i] <= found[i-1] {
+					t.Fatalf("sidecar found offsets not in order: [%d]=%d <= [%d]=%d",
 						i, found[i], i-1, found[i-1])
 				}
 			}

--- a/search_test.go
+++ b/search_test.go
@@ -3856,8 +3856,8 @@ func TestSearchLongPrefixStraddle(t *testing.T) {
 		// "<<" at the end of block 0, ">" + value at the start of block 1.
 		data := make([]byte, 0, bs*2)
 		data = append(data, filler[:bs-2]...)
-		data = append(data, '<', '<')              // block0[bs-2], block0[bs-1]
-		data = append(data, '>')                   // block1[0] -> prefix "<<>" straddles
+		data = append(data, '<', '<') // block0[bs-2], block0[bs-1]
+		data = append(data, '>')      // block1[0] -> prefix "<<>" straddles
 		data = append(data, []byte("NEEDLExyzabc")...)
 		data = append(data, filler...)
 		needle := append(append([]byte{}, prefix...), []byte("NEEDLE")...)
@@ -3977,6 +3977,69 @@ func TestSearchStreamingForwardStraddle(t *testing.T) {
 		}
 		if found != 1 {
 			t.Errorf("cpu%d: straddling match across a streaming block boundary was missed (found=%d)", cpu, found)
+		}
+	}
+}
+
+// TestSearchStraddleShortInteriorBlock covers a match that spans three blocks
+// because a mid-stream Flush emits an interior block shorter than len(pattern)-1.
+// Regression for a boundary scan that only spanned prevBlock+current and lost
+// the bytes before a tiny flushed block (found by FuzzSearchRoundtrip:
+// data="…sss…", flush leaving a 1-byte block, match straddling it).
+func TestSearchStraddleShortInteriorBlock(t *testing.T) {
+	const bs = minBlockSize
+	pat := []byte("NEEDLE") // len 6, so len(pattern)-1 = 5
+	for _, cpu := range []int{1, 4} {
+		for _, ml := range []int{4, 6, 8} { // 8 > len(pat): unusable table (all decoded)
+			for _, tiny := range []int{1, 2, 3} { // interior block shorter than 5
+				// Region of repeated pattern straddling the block0 / tiny / block2
+				// seams, with skippable 'x' filler elsewhere.
+				data := bytes.Repeat([]byte("x"), 3*bs)
+				copy(data[bs-2*len(pat):], bytes.Repeat(pat, 4)) // crosses block0 end
+				copy(data[bs+tiny-2:], bytes.Repeat(pat, 4))     // crosses tiny block end
+				copy(data[7:], pat)                              // control: inside block0
+				copy(data[2*bs+9:], pat)                         // control: inside block2
+
+				cfg := NewSearchTableConfig().WithMatchLen(ml)
+				var buf bytes.Buffer
+				w := NewWriter(&buf, WriterSearchTable(cfg), WriterBlockSize(bs), WriterConcurrency(cpu))
+				cut := bs + tiny // Flush after one full block + tiny bytes
+				if _, err := w.Write(data[:cut]); err != nil {
+					t.Fatal(err)
+				}
+				if err := w.Flush(); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := w.Write(data[cut:]); err != nil {
+					t.Fatal(err)
+				}
+				if err := w.Close(); err != nil {
+					t.Fatal(err)
+				}
+
+				var want []int64
+				for off := 0; ; {
+					i := bytes.Index(data[off:], pat)
+					if i < 0 {
+						break
+					}
+					want = append(want, int64(off+i))
+					off += i + 1
+				}
+				got := map[int64]bool{}
+				if err := NewBlockSearcher(bytes.NewReader(buf.Bytes())).Search(pat, func(r SearchResult) error {
+					got[r.StreamOffset] = true
+					return nil
+				}); err != nil {
+					t.Fatal(err)
+				}
+				for _, off := range want {
+					if !got[off] {
+						t.Fatalf("cpu=%d ml=%d tiny=%d: missed match at offset %d (want %d, got %d)",
+							cpu, ml, tiny, off, len(want), len(got))
+					}
+				}
+			}
 		}
 	}
 }

--- a/sidecar_search.go
+++ b/sidecar_search.go
@@ -98,9 +98,12 @@ type SidecarSearcher struct {
 	stats        SearchStats
 	// searchWindows is the pattern's matchLen-windows, enumerated once when the
 	// first usable table is seen; per-table presence is tallied into
-	// stats.Windows. Only populated under collectStats.
+	// stats.Windows. Only populated under collectStats. winCfg is the layout
+	// they were enumerated for; tallying stops if a later table's config differs
+	// (mixing layouts — e.g. a multi-config sidecar — would mislabel the counts).
 	searchWindows []windowSpec
 	winInit       bool
+	winCfg        SearchTableConfig
 
 	// Sidecar reader scratch + buffers used between blocks.
 	scratch    []byte
@@ -281,8 +284,11 @@ func (s *SidecarSearcher) Search(pattern []byte, fn func(SearchResult) error) er
 			s.pending = append(s.pending, blockTableEntry{cfg: cfg, reductions: reductions, table: tcopy})
 			if s.collectStats {
 				if !s.winInit {
+					s.winCfg = cfg
 					s.searchWindows = s.stats.initWindows(&cfg, pattern)
 					s.winInit = true
+				} else if s.searchWindows != nil && !sameSearchLayout(&s.winCfg, &cfg) {
+					s.searchWindows = nil // config drift: stop, mixed layouts would mislabel
 				}
 				s.stats.tallyWindows(s.searchWindows, cfg.baseTableSize, reductions, tcopy)
 				s.statsAccumTable(cfg.baseTableSize, reductions, tcopy, cl, false)
@@ -324,8 +330,11 @@ func (s *SidecarSearcher) Search(pattern []byte, fn func(SearchResult) error) er
 			s.pending = append(s.pending, blockTableEntry{cfg: cfg, reductions: reductions, table: tcopy})
 			if s.collectStats {
 				if !s.winInit {
+					s.winCfg = cfg
 					s.searchWindows = s.stats.initWindows(&cfg, pattern)
 					s.winInit = true
+				} else if s.searchWindows != nil && !sameSearchLayout(&s.winCfg, &cfg) {
+					s.searchWindows = nil // config drift: stop, mixed layouts would mislabel
 				}
 				s.stats.tallyWindows(s.searchWindows, cfg.baseTableSize, reductions, tcopy)
 				s.statsAccumTable(cfg.baseTableSize, reductions, tcopy, cl, true)

--- a/sidecar_search.go
+++ b/sidecar_search.go
@@ -75,6 +75,15 @@ type SidecarSearcher struct {
 	prevBlock []byte // decoded previous block (nil if not yet decoded / skipped)
 	prevLazy  *lazyMainBlock
 	deferred  *deferredMatch
+	// tailBuf holds the last len(pattern)-1 bytes of the current contiguous run
+	// of decoded blocks (mirrors BlockSearcher.tailBuf). It lets the boundary
+	// scan and the skip/defer guards see a match that straddles 3+ blocks — e.g.
+	// across a short Flush block shorter than len(pattern)-1 — where prevBlock
+	// alone is too short. tailOff is its stream offset; bbuf is reused scratch.
+	// Reset whenever a block is skipped or deferred (contiguity break).
+	tailBuf []byte
+	tailOff int64
+	bbuf    []byte
 
 	// Options.
 	bail         bool
@@ -87,6 +96,11 @@ type SidecarSearcher struct {
 	blockStart   int64 // uncompressed offset where the next block begins
 	blockMatches int
 	stats        SearchStats
+	// searchWindows is the pattern's matchLen-windows, enumerated once when the
+	// first usable table is seen; per-table presence is tallied into
+	// stats.Windows. Only populated under collectStats.
+	searchWindows []windowSpec
+	winInit       bool
 
 	// Sidecar reader scratch + buffers used between blocks.
 	scratch    []byte
@@ -175,6 +189,8 @@ func (s *SidecarSearcher) Search(pattern []byte, fn func(SearchResult) error) er
 	s.deferred = nil
 	s.prevBlock = nil
 	s.prevLazy = nil
+	s.tailBuf = s.tailBuf[:0]
+	s.winInit = false
 	s.blockStart = 0
 	s.pending = s.pending[:0]
 	s.streamInfos = s.streamInfos[:0]
@@ -264,6 +280,11 @@ func (s *SidecarSearcher) Search(pattern []byte, fn func(SearchResult) error) er
 			tcopy := s.copyPendingTable(table)
 			s.pending = append(s.pending, blockTableEntry{cfg: cfg, reductions: reductions, table: tcopy})
 			if s.collectStats {
+				if !s.winInit {
+					s.searchWindows = s.stats.initWindows(&cfg, pattern)
+					s.winInit = true
+				}
+				s.stats.tallyWindows(s.searchWindows, cfg.baseTableSize, reductions, tcopy)
 				s.statsAccumTable(cfg.baseTableSize, reductions, tcopy, cl, false)
 			}
 
@@ -302,6 +323,11 @@ func (s *SidecarSearcher) Search(pattern []byte, fn func(SearchResult) error) er
 			tcopy := s.copyPendingTable(table)
 			s.pending = append(s.pending, blockTableEntry{cfg: cfg, reductions: reductions, table: tcopy})
 			if s.collectStats {
+				if !s.winInit {
+					s.searchWindows = s.stats.initWindows(&cfg, pattern)
+					s.winInit = true
+				}
+				s.stats.tallyWindows(s.searchWindows, cfg.baseTableSize, reductions, tcopy)
 				s.statsAccumTable(cfg.baseTableSize, reductions, tcopy, cl, true)
 				// Compressed sub-block stats live on the cstDecoder after parse.
 				s.stats.CompressedBlocksTotal += s.cstDec.lastBlocks
@@ -351,11 +377,17 @@ func (s *SidecarSearcher) Search(pattern []byte, fn func(SearchResult) error) er
 				if s.bail && !anyUsable {
 					return ErrSearchTablesUnusable
 				}
-				if skip && (s.prevBlock == nil || !canBoundaryMatch(s.prevBlock, pattern)) {
-					// Definite skip — first flush any prior decode batch.
+				if skip {
+					// Decode the coalesced batch now so tailBuf reflects the run
+					// of blocks immediately preceding this one. The boundary guard
+					// needs that real tail; batched decoding would otherwise leave
+					// it stale from an earlier flush, and if that stale tail
+					// happened to be a pattern prefix every skip would be vetoed.
 					if err := flushBatch(); err != nil {
 						return err
 					}
+				}
+				if skip && (len(s.tailBuf) == 0 || !canBoundaryMatch(s.tailBuf, pattern)) {
 					if s.collectStats {
 						s.stats.BlocksSkipped++
 					}
@@ -369,6 +401,7 @@ func (s *SidecarSearcher) Search(pattern []byte, fn func(SearchResult) error) er
 						maxBlock:   s.maxBlock,
 					}
 					s.prevBlock = nil
+					s.tailBuf = s.tailBuf[:0]
 					if s.deferred != nil {
 						if err := s.flushDeferred(nil, fn); err != nil {
 							return err
@@ -382,32 +415,39 @@ func (s *SidecarSearcher) Search(pattern []byte, fn func(SearchResult) error) er
 				// via a straddling match into the next block, postpone the
 				// decision until the next block's table arrives. Restricted
 				// to single-config tables and no boundary risk from prev.
-				if !skip && i == 0 && len(tables) == 1 && len(s.streamInfos) == 1 && tables[0].table != nil && s.sideDeferred == nil &&
-					(s.prevBlock == nil || !canBoundaryMatch(s.prevBlock, pattern)) {
+				if !skip && i == 0 && len(tables) == 1 && len(s.streamInfos) == 1 && tables[0].table != nil && s.sideDeferred == nil {
 					t := &tables[0]
 					if hashes := patternDeferHashes(&t.cfg, t.table, t.reductions, pattern); hashes != nil {
+						// Flush first so tailBuf reflects the immediately-preceding
+						// block before the boundary guard (same staleness reason as
+						// the skip path above).
 						if err := flushBatch(); err != nil {
 							return err
 						}
-						refCopy := ref
-						s.sideDeferred = &refCopy
-						s.sideDeferredHashes = hashes
-						s.sideDeferredBase = t.cfg.baseTableSize
-						if s.collectStats {
-							s.stats.BlocksDeferred++
+						if len(s.tailBuf) == 0 || !canBoundaryMatch(s.tailBuf, pattern) {
+							refCopy := ref
+							s.sideDeferred = &refCopy
+							s.sideDeferredHashes = hashes
+							s.sideDeferredBase = t.cfg.baseTableSize
+							if s.collectStats {
+								s.stats.BlocksDeferred++
+							}
+							s.prevBlock = nil
+							s.tailBuf = s.tailBuf[:0]
+							s.prevLazy = &lazyMainBlock{
+								main:       s.main,
+								offset:     ref.offset,
+								uncompSize: ref.uncompSize,
+								ignoreCRC:  s.ignoreCRC,
+								maxBlock:   s.maxBlock,
+							}
+							// Do NOT advance blockStart here — the deferred
+							// resolution path advances it: processBlock advances
+							// on decode; resolveSideDeferred advances on skip.
+							continue
 						}
-						s.prevBlock = nil
-						s.prevLazy = &lazyMainBlock{
-							main:       s.main,
-							offset:     ref.offset,
-							uncompSize: ref.uncompSize,
-							ignoreCRC:  s.ignoreCRC,
-							maxBlock:   s.maxBlock,
-						}
-						// Do NOT advance blockStart here — the deferred
-						// resolution path advances it: processBlock advances
-						// on decode; resolveSideDeferred advances on skip.
-						continue
+						// Boundary risk from the real previous block — fall
+						// through and decode this block now.
 					}
 				}
 				// Must decode. tableNoMatch is true when the table proved
@@ -454,6 +494,7 @@ func (s *SidecarSearcher) Search(pattern []byte, fn func(SearchResult) error) er
 			s.pending = nil
 			s.prevBlock = nil
 			s.prevLazy = nil
+			s.tailBuf = s.tailBuf[:0]
 			s.streamInfos = s.streamInfos[:0]
 
 		case ChunkTypeStreamIdentifier:
@@ -488,6 +529,9 @@ func (s *SidecarSearcher) Search(pattern []byte, fn func(SearchResult) error) er
 			s.maxBlock = min(s.maxBlockCfg, mb)
 			// New stream — offsets/context don't cross stream boundaries.
 			s.blockStart = 0
+			s.prevBlock = nil
+			s.prevLazy = nil
+			s.tailBuf = s.tailBuf[:0]
 
 		default:
 			if ct <= maxNonSkippableChunk {
@@ -702,12 +746,35 @@ func (s *SidecarSearcher) processBlock(chunkType byte, chunkLen int, payload []b
 		// Block was decoded only because the prev block forced a boundary
 		// check. The table already proved no match inside this block — do
 		// not keep it as prevBlock or the cascade continues unboundedly.
+		if s.collectStats {
+			s.stats.BlocksBoundaryScanned++
+		}
 		s.prevBlock = nil
 	} else {
 		s.prevBlock = decoded
 	}
 	s.prevLazy = nil
 	return nil
+}
+
+// updateTail records blk (ending at stream offset endOff) as the most recent
+// contiguous decoded data, retaining its last keep bytes for the next block's
+// boundary scan. Mirrors BlockSearcher.updateTail; short blocks accumulate so
+// the tail spans keep bytes whenever that much contiguous data exists.
+func (s *SidecarSearcher) updateTail(blk []byte, endOff int64, keep int) {
+	if keep <= 0 {
+		s.tailBuf = s.tailBuf[:0]
+		return
+	}
+	if len(blk) >= keep {
+		s.tailBuf = append(s.tailBuf[:0], blk[len(blk)-keep:]...)
+	} else {
+		if drop := len(s.tailBuf) + len(blk) - keep; drop > 0 {
+			s.tailBuf = append(s.tailBuf[:0], s.tailBuf[min(drop, len(s.tailBuf)):]...)
+		}
+		s.tailBuf = append(s.tailBuf, blk...)
+	}
+	s.tailOff = endOff - int64(len(s.tailBuf))
 }
 
 // dispatchSidecarMatches mirrors BlockSearcher.dispatchMatches but uses
@@ -719,40 +786,65 @@ func (s *SidecarSearcher) dispatchSidecarMatches(blk []byte, blockOff int64, pat
 	} else if s.prevLazy != nil {
 		prevBlockStart = blockOff - int64(s.prevLazy.uncompSize)
 	}
-	if s.prevBlock != nil && len(pattern) > 1 {
-		tail := s.prevBlock[max(0, len(s.prevBlock)-len(pattern)+1):]
+	// Boundary scan over the rolling tail of the contiguous decoded run, so a
+	// match straddling 3+ blocks (e.g. across a short Flush block shorter than
+	// len(pattern)-1) is found even when prevBlock alone is too short.
+	if len(s.tailBuf) > 0 && len(pattern) > 1 {
+		tail := s.tailBuf
 		head := blk[:min(len(blk), len(pattern)-1)]
-		boundary := append(append([]byte(nil), tail...), head...)
+		s.bbuf = append(append(s.bbuf[:0], tail...), head...)
 		bOff := 0
 		for {
-			idx := bytes.Index(boundary[bOff:], pattern)
+			idx := bytes.Index(s.bbuf[bOff:], pattern)
 			if idx < 0 {
 				break
 			}
 			absIdx := bOff + idx
-			matchInPrev := len(tail) - absIdx
-			if matchInPrev <= 0 || matchInPrev >= len(pattern) {
+			matchInTail := len(tail) - absIdx
+			if matchInTail <= 0 || matchInTail >= len(pattern) {
 				bOff = absIdx + 1
 				continue
 			}
-			streamOff := blockOff - int64(matchInPrev)
-			result := SearchResult{
-				Blocks:       [2][]byte{s.prevBlock, blk},
-				Offset:       len(s.prevBlock) - matchInPrev,
-				StreamOffset: streamOff,
-				BlockStart:   prevBlockStart,
-				PrevBlockLen: len(s.prevBlock),
+			streamOff := s.tailOff + int64(absIdx)
+			// Prefer the full previous block for context; fall back to the tail
+			// when the match starts before prevBlock (a 3+ block straddle).
+			var result SearchResult
+			var defOff int
+			var defStart int64
+			var defBlk []byte
+			if s.prevBlock != nil && streamOff >= prevBlockStart {
+				off := int(streamOff - prevBlockStart)
+				result = SearchResult{
+					Blocks:       [2][]byte{s.prevBlock, blk},
+					Offset:       off,
+					StreamOffset: streamOff,
+					BlockStart:   prevBlockStart,
+					PrevBlockLen: len(s.prevBlock),
+				}
+				defOff, defStart, defBlk = off, prevBlockStart, s.prevBlock
+			} else {
+				result = SearchResult{
+					Blocks:       [2][]byte{tail, blk},
+					Offset:       absIdx,
+					StreamOffset: streamOff,
+					BlockStart:   s.tailOff,
+					PrevBlockLen: len(tail),
+				}
+				defOff, defStart = absIdx, s.tailOff
 			}
 			s.blockMatches++
 			if err := fn(result); err != nil {
 				if !errors.Is(err, ErrSearchForward) {
 					return err
 				}
+				if defBlk == nil { // tailBuf is reused next block; copy it
+					defBlk = append([]byte(nil), tail...)
+				}
 				s.deferred = &deferredMatch{
 					streamOff: streamOff,
-					blockOff:  blockOff - int64(len(s.prevBlock)),
-					matchOff:  len(s.prevBlock) - matchInPrev,
-					blk:       s.prevBlock,
+					blockOff:  defStart,
+					matchOff:  defOff,
+					blk:       defBlk,
 				}
 			}
 			bOff = absIdx + 1
@@ -763,6 +855,7 @@ func (s *SidecarSearcher) dispatchSidecarMatches(blk []byte, blockOff int64, pat
 	for {
 		idx := bytes.Index(blk[off:], pattern)
 		if idx < 0 {
+			s.updateTail(blk, blockOff+int64(len(blk)), len(pattern)-1)
 			return nil
 		}
 		matchOff := off + idx

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -1318,3 +1318,122 @@ func BenchmarkSidecarSearchCompressedVsUncompressed(b *testing.B) {
 	b.Run("uncompressed", func(b *testing.B) { run(b, mainU, sideU) })
 	b.Run("compressed", func(b *testing.B) { run(b, mainC, sideC) })
 }
+
+// TestSearchConcatenatedNoCrossStreamStraddle verifies a pattern straddling the
+// boundary between two concatenated streams is NOT reported: concatenated
+// streams are independent and offsets restart at 0. d1 ends with the full
+// pattern (one real match) followed by the pattern's head; d2 begins with the
+// pattern's tail. A searcher that leaked boundary state (prevBlock/tailBuf)
+// across the stream identifier would report a spurious second, straddling
+// match. Covers both the inline and sidecar searchers.
+func TestSearchConcatenatedNoCrossStreamStraddle(t *testing.T) {
+	pattern := []byte("QWERTYUIOPASDFGH")
+	filler := bytes.Repeat([]byte("the quick brown fox 0123456789\n"), 500)
+	d1 := append(append(append([]byte{}, filler...), pattern...), pattern[:10]...)
+	d2 := append(append([]byte{}, pattern[10:]...), filler...)
+	if countOccurrences(d1, pattern) != 1 || countOccurrences(d2, pattern) != 0 {
+		t.Fatalf("setup: d1=%d d2=%d, want 1,0", countOccurrences(d1, pattern), countOccurrences(d2, pattern))
+	}
+	cfg := NewSearchTableConfig().WithMatchLen(6)
+
+	type searcher interface {
+		Search([]byte, func(SearchResult) error) error
+	}
+	count := func(s searcher) int {
+		n := 0
+		if err := s.Search(pattern, func(SearchResult) error { n++; return nil }); err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		return n
+	}
+
+	// Inline: two concatenated tabled streams in one buffer.
+	var inline bytes.Buffer
+	w := NewWriter(&inline, WriterBlockSize(minBlockSize), WriterConcurrency(1), WriterSearchTable(cfg))
+	if _, err := w.Write(d1); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	w.Reset(&inline)
+	if _, err := w.Write(d2); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// Decoded output is d1||d2 and contains the pattern twice (real + straddle).
+	dec, err := io.ReadAll(NewReader(bytes.NewReader(inline.Bytes())))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got := countOccurrences(dec, pattern); got != 2 {
+		t.Fatalf("decoded output has %d occurrences, want 2 (real + straddle)", got)
+	}
+	if got := count(NewBlockSearcher(bytes.NewReader(inline.Bytes()))); got != 1 {
+		t.Fatalf("inline concatenated search: got %d matches, want 1 (no cross-stream straddle)", got)
+	}
+
+	// Sidecar: the same two streams with tables in the sidecar.
+	var main, side bytes.Buffer
+	w2 := NewWriter(&main, WriterBlockSize(minBlockSize), WriterConcurrency(1), WriterSearchTable(cfg), WriterSidecar(&side))
+	if _, err := w2.Write(d1); err != nil {
+		t.Fatal(err)
+	}
+	if err := w2.Close(); err != nil {
+		t.Fatal(err)
+	}
+	w2.Reset(&main)
+	if _, err := w2.Write(d2); err != nil {
+		t.Fatal(err)
+	}
+	if err := w2.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := count(NewSidecarSearcher(bytes.NewReader(main.Bytes()), bytes.NewReader(side.Bytes()))); got != 1 {
+		t.Fatalf("sidecar concatenated search: got %d matches, want 1 (no cross-stream straddle)", got)
+	}
+}
+
+// TestSidecarSearchWindowStatsConfigDrift verifies per-window stats collection
+// stops on config drift (a multi-config sidecar presents tables with different
+// window layouts) rather than mixing incompatible tables into one set of
+// counts. Without the guard, every table of every config is tallied, pushing
+// the per-window denominator above the block count.
+func TestSidecarSearchWindowStatsConfigDrift(t *testing.T) {
+	data := makeTestData(120 << 10)
+	var main bytes.Buffer
+	w := NewWriter(&main, WriterBlockSize(32<<10), WriterConcurrency(1))
+	if _, err := w.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var side bytes.Buffer
+	if err := BuildSidecar(&side, bytes.NewReader(main.Bytes()),
+		SidecarSearchTable(NewSearchTableConfig().WithMatchLen(6)),
+		SidecarSearchTable(NewSearchTableConfig().WithMatchLen(4).WithBytePrefix('"', ':')),
+	); err != nil {
+		t.Fatalf("BuildSidecar: %v", err)
+	}
+
+	ss := NewSidecarSearcher(bytes.NewReader(main.Bytes()), bytes.NewReader(side.Bytes()), BlockSearchCollectStats())
+	if err := ss.Search([]byte(`"level":"INFO"`), func(SearchResult) error { return nil }); err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	st := ss.Stats()
+	if len(st.Windows) == 0 {
+		t.Fatal("no pattern windows enumerated")
+	}
+	denom := st.Windows[0].Present + st.Windows[0].Absent
+	for i, ws := range st.Windows {
+		if ws.Present+ws.Absent != denom {
+			t.Fatalf("window %d tallied %d times, want %d (inconsistent)", i, ws.Present+ws.Absent, denom)
+		}
+	}
+	if denom > st.BlocksTotal {
+		t.Fatalf("window denominator %d exceeds %d blocks — incompatible configs were mixed into the counts", denom, st.BlocksTotal)
+	}
+}

--- a/writer.go
+++ b/writer.go
@@ -71,7 +71,13 @@ func NewWriter(w io.Writer, opts ...WriterOption) *Writer {
 		w2.obufLen += w2.searchMaxChunk
 	}
 	w2.paramsOK = true
-	w2.ibuf = make([]byte, 0, w2.blockSize)
+	// With search tables, hold one block plus its overlap so the search table
+	// for a streaming block can be built once the next block's bytes arrive.
+	ibufCap := w2.blockSize
+	if w2.searchCfg != nil {
+		ibufCap += w2.searchCfg.overlapBytes()
+	}
+	w2.ibuf = make([]byte, 0, ibufCap)
 	w2.buffers.New = func() interface{} {
 		return make([]byte, w2.obufLen)
 	}
@@ -272,20 +278,22 @@ func (w *Writer) Write(p []byte) (nRet int, errRet error) {
 		return 0, err
 	}
 	if w.flushOnWrite {
-		return w.write(p)
+		return w.write(p, true, true)
 	}
 	// If we exceed the input buffer size, start writing
 	for len(p) > (cap(w.ibuf)-len(w.ibuf)) && w.err(nil) == nil {
 		var n int
 		if len(w.ibuf) == 0 {
-			// Large write, empty buffer.
-			// Write directly from p to avoid copy.
-			n, _ = w.write(p)
+			// Large write, empty buffer. Write directly from p to avoid a copy.
+			// write() retains a trailing block + overlap (deferred emission); the
+			// retained tail stays in p and is buffered into w.ibuf below.
+			n, _ = w.write(p, false, false)
 		} else {
 			n = copy(w.ibuf[len(w.ibuf):cap(w.ibuf)], p)
 			w.ibuf = w.ibuf[:len(w.ibuf)+n]
-			w.write(w.ibuf)
-			w.ibuf = w.ibuf[:0]
+			consumed, _ := w.write(w.ibuf, false, false)
+			// Slide the retained tail (held block + overlap) to the front.
+			w.ibuf = w.ibuf[:copy(w.ibuf, w.ibuf[consumed:])]
 		}
 		nRet += n
 		p = p[n:]
@@ -436,7 +444,7 @@ func (w *Writer) EncodeBuffer(buf []byte) (err error) {
 	}
 
 	if w.flushOnWrite {
-		_, err := w.write(buf)
+		_, err := w.write(buf, true, false)
 		return err
 	}
 	// Flush queued data first.
@@ -447,7 +455,7 @@ func (w *Writer) EncodeBuffer(buf []byte) (err error) {
 		}
 	}
 	if w.concurrency == 1 {
-		_, err := w.writeSync(buf)
+		_, err := w.writeSync(buf, true, false)
 		return err
 	}
 
@@ -593,16 +601,19 @@ func (w *Writer) encodeBlock(obuf, uncompressed []byte) int {
 	return n
 }
 
-func (w *Writer) write(p []byte) (nRet int, errRet error) {
+func (w *Writer) write(p []byte, final, omitTrailing bool) (nRet int, errRet error) {
 	if err := w.err(nil); err != nil {
 		return 0, err
 	}
 	if w.concurrency == 1 {
-		return w.writeSync(p)
+		return w.writeSync(p, final, omitTrailing)
 	}
 
 	// Spawn goroutine and write block to output channel.
 	for len(p) > 0 {
+		if !final && w.searchCfg != nil && len(p) < w.blockSize+w.searchCfg.overlapBytes() {
+			break // retain a block + its overlap for the next call (deferred emission)
+		}
 		if !w.wroteStreamHeader {
 			w.wroteStreamHeader = true
 			hWriter := make(chan result)
@@ -640,6 +651,14 @@ func (w *Writer) write(p []byte) (nRet int, errRet error) {
 		obuf := w.buffers.Get().([]byte)[:w.obufLen]
 		copy(inbuf[obufHeaderLen:], uncompressed)
 		uncompressed = inbuf[obufHeaderLen:]
+
+		// A flushed/final block without full overlap omits its table (pass a nil
+		// config to the goroutine): a boundary-incomplete table could hide a
+		// straddling match, so emit none and let the searcher always scan it.
+		gcfg := w.searchCfg
+		if omitTrailing && w.searchCfg != nil && len(overlap) < w.searchCfg.overlapBytes() {
+			gcfg = nil
+		}
 
 		output := make(chan result)
 		w.output <- output
@@ -700,8 +719,11 @@ func (w *Writer) write(p []byte) (nRet int, errRet error) {
 				res.b = dbuf
 				res.pooled = obuf
 			} else if searchLen > 0 {
-				// Search chunk in inbuf[:searchLen] (the unused buffer), data in dbuf.
-				// Slide into inbuf since it has capacity.
+				// Assemble [search chunk][data chunk] in inbuf. inbuf has capacity
+				// obufLen but was sliced to len(uncompressed)+obufHeaderLen, which is
+				// shorter than the smc-based offsets below for a small block — extend
+				// it to cap so the slices and the data copy aren't out of range.
+				inbuf = inbuf[:cap(inbuf)]
 				start := smc - searchLen
 				copy(inbuf[start:], inbuf[:searchLen])
 				copy(inbuf[smc:], dbuf)
@@ -715,7 +737,7 @@ func (w *Writer) write(p []byte) (nRet int, errRet error) {
 			output <- res
 
 			w.buffers.Put(inbuf)
-		}(w.searchCfg, overlap)
+		}(gcfg, overlap)
 		nRet += len(uncompressed)
 	}
 	return nRet, nil
@@ -731,7 +753,7 @@ func (w *Writer) writeFull(inbuf []byte) (errRet error) {
 	}
 
 	if w.concurrency == 1 {
-		_, err := w.writeSync(inbuf[obufHeaderLen:])
+		_, err := w.writeSync(inbuf[obufHeaderLen:], true, false)
 		return err
 	}
 
@@ -829,7 +851,7 @@ func (w *Writer) writeFull(inbuf []byte) (errRet error) {
 	return nil
 }
 
-func (w *Writer) writeSync(p []byte) (nRet int, errRet error) {
+func (w *Writer) writeSync(p []byte, final, omitTrailing bool) (nRet int, errRet error) {
 	if err := w.err(nil); err != nil {
 		return 0, err
 	}
@@ -851,6 +873,9 @@ func (w *Writer) writeSync(p []byte) (nRet int, errRet error) {
 	}
 
 	for len(p) > 0 {
+		if !final && w.searchCfg != nil && len(p) < w.blockSize+w.searchCfg.overlapBytes() {
+			break // retain a block + its overlap for the next call (deferred emission)
+		}
 		var uncompressed []byte
 		if len(p) > w.blockSize {
 			uncompressed, p = p[:w.blockSize], p[w.blockSize:]
@@ -892,7 +917,9 @@ func (w *Writer) writeSync(p []byte) (nRet int, errRet error) {
 			if err := w.writeSidecarStartIfNeeded(); err != nil {
 				return 0, err
 			}
-			if w.searchCfg != nil && n2 > 0 {
+			// Omit the table for a flushed block without full overlap (its 0x47
+			// ref is still written); the searcher always scans tableless blocks.
+			if w.searchCfg != nil && n2 > 0 && !(omitTrailing && len(p) < w.searchCfg.overlapBytes()) {
 				overlap := p[:min(len(p), w.searchCfg.overlapBytes())]
 				if err := w.writeSearchTableSync(uncompressed, overlap); err != nil {
 					return 0, err
@@ -901,7 +928,7 @@ func (w *Writer) writeSync(p []byte) (nRet int, errRet error) {
 			if err := w.writeSidecarRemoteRef(mainBlockOffset, len(uncompressed)); err != nil {
 				return 0, err
 			}
-		} else if w.searchCfg != nil && n2 > 0 {
+		} else if w.searchCfg != nil && n2 > 0 && !(omitTrailing && len(p) < w.searchCfg.overlapBytes()) {
 			overlap := p[:min(len(p), w.searchCfg.overlapBytes())]
 			if err := w.writeSearchTableSync(uncompressed, overlap); err != nil {
 				return 0, err
@@ -940,6 +967,14 @@ func (w *Writer) writeSync(p []byte) (nRet int, errRet error) {
 // AsyncFlush writes any buffered bytes to a block and starts compressing it.
 // It does not wait for the output has been written as Flush() does.
 func (w *Writer) AsyncFlush() error {
+	// A user-initiated flush emits the buffered block without forward overlap;
+	// omitTrailing makes it skip the (boundary-incomplete) search table so the
+	// block is always scanned. Close uses omitTrailing=false to keep the
+	// stream-final block's table.
+	return w.asyncFlush(true)
+}
+
+func (w *Writer) asyncFlush(omitTrailing bool) error {
 	if err := w.err(nil); err != nil {
 		return err
 	}
@@ -947,11 +982,11 @@ func (w *Writer) AsyncFlush() error {
 	// Queue any data still in input buffer.
 	if len(w.ibuf) != 0 {
 		if !w.wroteStreamHeader {
-			_, err := w.writeSync(w.ibuf)
+			_, err := w.writeSync(w.ibuf, true, omitTrailing)
 			w.ibuf = w.ibuf[:0]
 			return w.err(err)
 		} else {
-			_, err := w.write(w.ibuf)
+			_, err := w.write(w.ibuf, true, omitTrailing)
 			w.ibuf = w.ibuf[:0]
 			err = w.err(err)
 			if err != nil {
@@ -964,8 +999,16 @@ func (w *Writer) AsyncFlush() error {
 
 // Flush flushes the Writer to its underlying io.Writer.
 // This does not apply padding.
+//
+// When search tables are enabled, the block flushed here is written without a
+// search table (its following bytes aren't available yet to index boundary
+// windows); it remains fully searchable but is always scanned, not skipped.
 func (w *Writer) Flush() error {
-	if err := w.AsyncFlush(); err != nil {
+	return w.flush(true)
+}
+
+func (w *Writer) flush(omitTrailing bool) error {
+	if err := w.asyncFlush(omitTrailing); err != nil {
 		return err
 	}
 
@@ -1006,7 +1049,9 @@ func (w *Writer) CloseIndex() ([]byte, error) {
 }
 
 func (w *Writer) closeIndex(idx bool) ([]byte, error) {
-	err := w.Flush()
+	// omitTrailing=false: the stream-final block has no successor, so its
+	// no-overlap table is sound and worth keeping (unlike a mid-stream flush).
+	err := w.flush(false)
 	if w.output != nil {
 		close(w.output)
 		w.writerWg.Wait()


### PR DESCRIPTION
Fix prefixed indexes missing the final match (prefix at the end of block). This forced decoding blocks just to check if this match existed.

Fix concurrent encoding (streaming) not indexing correctly, and not always providing overlap bytes. We will not write an search block on Flush calls.

Both were implementation mistakes. Specification is clarified and implementation guide updated.

Before/after example:
```
λ go build&&mz c -2 -bs=1MB -search -search.sidecar=false -search.prefixes=',\":/{}[]' -search.len=8 -search.lim=5 github-june-2days-2019.json
Compressing github-june-2days-2019.json -> github-june-2days-2019.json.mz 6273951764 -> 1056068951 [16.83% 5.941:1]; 3995.9MB/s

λ mz search -c -v \"DeleteEvent\",\"actor\":{\"id\":32803738,\"login\":\"promehul\" github-june-2days-2019.json.mz
github-june-2days-2019.json.mz: search info: matchLen=8 baseTableSize=20 (1048576 entries) mask-prefix (9 bytes)
4
github-june-2days-2019.json.mz took 5.839s 1074.5 MB/s
Blocks total: 5984, skipped: 9 (0.2%), deferred: 1 (0.0%, 1 skipped)
Blocks searched: 5975 (99.8%), false positive: 5972 (99.9%)
Bytes skipped: 890263 compressed, searched: 6264514580 uncompressed
Tables: 5984 present, 0 missing, 0 unusable
Table bits/byte: 0.0981, log2: 18.7, avg reductions: 1.3
Table total: 76897877 bytes, avg 12850 bytes/table, 1.23% of 6273951764 uncompressed
Table population: avg 3.4%, min 2.5%, max 5.0%
Table types: 0 uncompressed (0x45), 5984 compressed (0x46)
Compressed tables: 5984 (100.0% of total), 76897877 wire bytes, 327819264 uncompressed bitmap bytes (23.46% ratio)
 Sub-blocks: 10026 total (10026 tabled, 0 raw, 0 RLE, 0 sparse); 9621 tables emitted (share=0.96 tables/tabled-block)
 Payload bytes: tabled=76182921 raw=0 RLE=0 sparse=0; table-header bytes=429666

λ git checkout -
Switched to branch 'fix-prefix-indexed'
Your branch is up to date with 'klauspost/fix-prefix-indexed'.

λ go build&&mz c -2 -bs=1MB -search -search.sidecar=false -search.prefixes=',\":/{}[]' -search.len=8 -search.lim=5 github-june-2days-2019.json
Compressing github-june-2days-2019.json -> github-june-2days-2019.json.mz 6273951764 -> 1056068951 [16.83% 5.941:1]; 4034.6MB/s

λ mz search -c -v \"DeleteEvent\",\"actor\":{\"id\":32803738,\"login\":\"promehul\" github-june-2days-2019.json.mz
github-june-2days-2019.json.mz: search info: matchLen=8 baseTableSize=20 (1048576 entries) mask-prefix (9 bytes)
4
github-june-2days-2019.json.mz took 771ms 8137.4 MB/s
Blocks total: 5984, skipped: 5970 (99.8%), deferred: 5969 (99.7%, 5962 skipped)
Blocks searched: 14 (0.2%), false positive: 11 (78.6%)
Bytes skipped: 976920471 compressed, searched: 13953044 uncompressed
Tables: 5984 present, 0 missing, 0 unusable
Table bits/byte: 0.0981, log2: 18.7, avg reductions: 1.3
Table total: 76897877 bytes, avg 12850 bytes/table, 1.23% of 6273951764 uncompressed
Table population: avg 3.4%, min 2.5%, max 5.0%
Table types: 0 uncompressed (0x45), 5984 compressed (0x46)
Compressed tables: 5984 (100.0% of total), 76897877 wire bytes, 327819264 uncompressed bitmap bytes (23.46% ratio)
 Sub-blocks: 10026 total (10026 tabled, 0 raw, 0 RLE, 0 sparse); 9621 tables emitted (share=0.96 tables/tabled-block)
 Payload bytes: tabled=76182921 raw=0 RLE=0 sparse=0; table-header bytes=429666
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customizable Bloom Filter stream search and an option to print per-window search statistics.

* **Documentation**
  * Clarified streaming, concurrency, flushing, and block-boundary indexing behavior for search.

* **Bug Fixes**
  * Fixed long-prefix boundary/indexing and deferral so straddling matches are found across streaming, concurrency, and mid-stream flushes; flushed blocks remain searchable.

* **Tests**
  * Added extensive fuzz, regression, and sidecar tests covering streaming, boundaries, flushes, and encode-method equivalence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->