### PR TITLE
Support prefix-only search

### DIFF
--- a/SEARCH.md
+++ b/SEARCH.md
@@ -24,6 +24,16 @@ are hashed and checked against the table:
 - If **any** window hash is not set: the block **definitely** doesn't contain the pattern — skip it.
 - If **all** window hashes are set: the block **might** contain the pattern — decode and search.
 
+The settings used to generate the table are crucial for the search efficiency.
+Therefore, the more you know about what you expect to be searching for, the smaller 
+or better you will be able to make the table.
+
+Searching for longer or unique strings will produce fewer false positives, so search will
+have to decode fewer blocks – and therefore be able to skip them entirely.
+
+All examples will be given using strings. However, all input is treated as raw bytes.
+So searches can be performed on any type of data.
+
 #### Example
 
 Say you are indexing a block with hashes of 4 bytes. This means that a block witj `abcdefgh` will be
@@ -176,6 +186,15 @@ with a 256-bit bitmask. Both produce the same result.
 cfg := minlz.NewSearchTableConfig().WithBytePrefix('"', ':')
 ```
 
+#### Choosing good prefix bytes
+
+Pick bytes that immediately precede the values you'll search for:
+
+- **JSON data:** `"` and `:` — values always follow `":` or `:[`.
+- **CSV data:** `,` or `\t` — field separators.
+- **Key=value formats:** `=` precedes values.
+- **Log lines with fields:** space, tab, `=`, or `:`.
+
 #### Long prefix
 
 Long prefix only indexes positions preceded by an exact multi-byte sequence (1–256 bytes):
@@ -190,6 +209,22 @@ occurrence in the pattern.
 
 When no prefix bytes appear in the search pattern, the table cannot be used and the
 searcher falls back to full block decode.
+
+#### Long Exact Matches
+
+It is possible to use a long prefix to match an exact multibyte sequence.
+This will only be helpful if the phrase is unlikely to appear in the stream.
+
+Let's say you are looking for the rare phrase `_INTERNAL_EXCEPTION` in streams.
+This can be specified as the long prefix so the searcher can reject blocks 
+that do not have any entries at all.
+
+The only exception is the very last block on the stream, which will always need to be decoded.
+If you would like to avoid that, set the match length to 1 and truncate one byte, 
+so the prefix is `_INTERNAL_EXCEPTIO`.
+
+In most cases both approaches are equally effective. But there can be exceptions, for
+example, if the shorter prefix is very common within the stream.
 
 ##### Extras
 
@@ -225,14 +260,6 @@ When to avoid it:
 - Queries are short and would not fill `matchLen + E` bytes after the prefix; those
   occurrences become unusable and the searcher falls back.
 
-#### Choosing good prefix bytes
-
-Pick bytes that immediately precede the values you'll search for:
-
-- **JSON data:** `"` and `:` — values always follow `":` or `:[`.
-- **CSV data:** `,` or `\t` — field separators.
-- **Key=value formats:** `=` precedes values.
-- **Log lines with fields:** space, tab, `=`, or `:`.
 
 ### Compressed Search Tables
 
@@ -496,17 +523,17 @@ serialization automatically.
 
 Configuration methods:
 
-| Method                          | Description                                                    |
-|---------------------------------|----------------------------------------------------------------|
-| `NewSearchTableConfig()`        | Create config with defaults (matchLen=6, no prefix, compressed)|
-| `WithMatchLen(n)`               | Set match length 1–8                                           |
-| `WithBytePrefix(b...)`          | Set 1–8 prefix bytes (>8 auto-promotes to bitmask)             |
-| `WithMaskPrefix(mask)`          | Set a 256-bit prefix bitmask                                   |
-| `WithLongPrefix(p)`             | Set a multi-byte prefix (1–256 bytes)                          |
-| `WithMaxPopulation(pct)`        | Discard tables above this population % (default 70)            |
-| `WithMaxReducedPopulation(pct)` | Stop reducing above this population % (default 25, 10 w/prefix)|
-| `WithCompression(opts...)`      | Tune the per-block table compression (on by default)           |
-| `WithoutCompression()`          | Disable per-block table compression (emit 0x45 only)           |
+| Method                          | Description                                                     |
+|---------------------------------|-----------------------------------------------------------------|
+| `NewSearchTableConfig()`        | Create config with defaults (matchLen=6, no prefix, compressed) |
+| `WithMatchLen(n)`               | Set match length 1–8                                            |
+| `WithBytePrefix(b...)`          | Set 1–8 prefix bytes (>8 auto-promotes to bitmask)              |
+| `WithMaskPrefix(mask)`          | Set a 256-bit prefix bitmask                                    |
+| `WithLongPrefix(p)`             | Set a multi-byte prefix (1–256 bytes)                           |
+| `WithMaxPopulation(pct)`        | Discard tables above this population % (default 70)             |
+| `WithMaxReducedPopulation(pct)` | Stop reducing above this population % (default 25, 10 w/prefix) |
+| `WithCompression(opts...)`      | Tune the per-block table compression (on by default)            |
+| `WithoutCompression()`          | Disable per-block table compression (emit 0x45 only)            |
 
 Decompressing the stream will ignore the search tables.
 

--- a/SEARCH.md
+++ b/SEARCH.md
@@ -188,9 +188,9 @@ cfg := minlz.NewSearchTableConfig().WithBytePrefix('"', ':')
 
 #### Choosing good prefix bytes
 
-Pick bytes that immediately precede the values you'll search for:
+Pick bytes that immediately precede the values you'll search for. For example:
 
-- **JSON data:** `"` and `:` — values always follow `":` or `:[`.
+- **Dense JSON data:** `"` and `:` — values always follow `":` or `:[`.
 - **CSV data:** `,` or `\t` — field separators.
 - **Key=value formats:** `=` precedes values.
 - **Log lines with fields:** space, tab, `=`, or `:`.

--- a/SPEC_SEARCH.md
+++ b/SPEC_SEARCH.md
@@ -669,6 +669,16 @@ a match straddling that boundary is still found via the decoded-block boundary
 check (B.2/B.3); it simply can't be skipped. The stream's final block has no
 successor (hence no forward straddle), so it keeps its table.
 
+That final-block table is built **without forward overlap**, so it omits prefix
+occurrences in the block's last `len(prefix) - 1 + matchLen + Extra Matches`
+bytes — their windows would lie past end-of-stream. For an ordinary pattern this
+is harmless: a complete match's first window lies inside the match, hence inside
+the block, so it is indexed. But a **prefix-only** query — a pattern too short to
+carry a `matchLen` window after the prefix (e.g. the pattern IS the prefix),
+answered purely by table emptiness (3.3.1) — cannot trust the final block's
+all-zero table. A searcher MUST scan the stream's final block rather than skip it
+on an empty table when answering such a query.
+
 **Deferral rule.** Because every tabled block carries full overlap, for a real
 match straddling N→N+1 every window absent from block N's table is present in
 block N+1's table. The searcher therefore defers **all** absent windows after the

--- a/search_reader.go
+++ b/search_reader.go
@@ -343,6 +343,15 @@ type BlockSearcher struct {
 	deferred      *deferredMatch // pending ErrSearchForward re-dispatch
 	pending       *pendingBlock  // block deferred pending next table check
 	cstDec        *cstDecoder    // lazy decoder state for 0x46 chunks
+	// tailRescue is set when the most recently processed block was skipped only
+	// because its (prefix) search table was all-zero. That skip is sound for any
+	// block with forward overlap, but a stream's final block is tabled without
+	// overlap (SPEC §B.4.3), so a prefix occurrence in its last bytes can be
+	// unindexed. The block stays buffered in prevLazy; if it turns out to be the
+	// stream's last block (end-of-stream reached with this still set) it is
+	// decoded and scanned instead of skipped. Cleared when a later block is processed.
+	tailRescue    bool
+	tailRescueOff int64 // stream offset where the pending block starts
 	infoCallback  func(SearchTableConfig)
 	maxBlock      int
 	readHeader    bool
@@ -448,6 +457,7 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 	s.pending = nil
 	s.prevLazy = nil
 	s.tailBuf = s.tailBuf[:0]
+	s.tailRescue = false
 	s.winInit = false
 
 	if s.collectStats {
@@ -461,6 +471,9 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 					if err := s.resolvePending(pattern, fn); err != nil {
 						return err
 					}
+				}
+				if err := s.rescueTail(pattern, fn); err != nil {
+					return err
 				}
 				if s.deferred != nil {
 					if err := s.flushDeferred(nil, fn); err != nil {
@@ -498,9 +511,13 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 			if blockSize > maxBlockSize {
 				return ErrCorrupt
 			}
-			// A concatenated stream starts here. Flush any pending forward-context
-			// dispatch and drop per-stream boundary state so matches and offsets
-			// don't straddle into the new stream (which restarts at offset 0).
+			// A concatenated stream starts here. Scan any held-back tail block
+			// from the prior stream, flush any pending forward-context dispatch,
+			// and drop per-stream boundary state so matches and offsets don't
+			// straddle into the new stream (which restarts at offset 0).
+			if err := s.rescueTail(pattern, fn); err != nil {
+				return err
+			}
 			if s.deferred != nil {
 				if err := s.flushDeferred(nil, fn); err != nil {
 					return err
@@ -693,6 +710,7 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 			if s.collectStats {
 				s.stats.BlocksTotal++
 			}
+			s.tailRescue = false
 			tableNoMatch := false
 			deferrable := false
 			if s.blockTable != nil {
@@ -712,6 +730,10 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 							s.stats.BlocksSkipped++
 							s.stats.CompBytesSkipped += int64(chunkLen)
 						}
+						// An all-zero table can't prove absence in a no-overlap
+						// final block; remember it so EOF scans this block.
+						s.tailRescue = tableAllZero(savedTable)
+						s.tailRescueOff = s.blockStart
 						s.blockStart += int64(decompLen)
 						if s.deferred != nil {
 							if err := s.flushDeferred(nil, fn); err != nil {
@@ -851,9 +873,11 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 			if s.collectStats {
 				s.stats.BlocksTotal++
 			}
+			s.tailRescue = false
 			tableNoMatch := false
 			if s.blockTable != nil {
-				canUse, match := patternCanMatch(&s.blockInfo, s.blockTable, s.blockReductions, pattern)
+				savedTable := s.blockTable
+				canUse, match := patternCanMatch(&s.blockInfo, savedTable, s.blockReductions, pattern)
 				s.blockTable = nil
 				if canUse && !match {
 					if len(s.tailBuf) == 0 || !canBoundaryMatch(s.tailBuf, pattern) {
@@ -865,6 +889,10 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 							s.stats.BlocksSkipped++
 							s.stats.CompBytesSkipped += int64(chunkLen)
 						}
+						// An all-zero table can't prove absence in a no-overlap
+						// final block; remember it so EOF scans this block.
+						s.tailRescue = tableAllZero(savedTable)
+						s.tailRescueOff = s.blockStart
 						s.blockStart += int64(decompLen)
 						if s.deferred != nil {
 							if err := s.flushDeferred(nil, fn); err != nil {
@@ -960,6 +988,10 @@ func (s *BlockSearcher) Search(pattern []byte, fn func(r SearchResult) error) er
 				if !s.readFull(s.tmp[:chunkLen]) {
 					return s.err
 				}
+			}
+			// End of this stream — scan a tail block held back from skipping.
+			if err := s.rescueTail(pattern, fn); err != nil {
+				return err
 			}
 			s.readHeader = false
 			continue
@@ -1317,6 +1349,47 @@ func (s *BlockSearcher) resolvePending(pattern []byte, fn func(SearchResult) err
 	return nil
 }
 
+// rescueTail scans a block that was skipped only because its (prefix) search
+// table was all-zero, once that block proves to be a stream's final block. The
+// final block is tabled without forward overlap (SPEC §B.4.3), so an all-zero
+// table cannot prove a prefix-only pattern absent from it. The block stays
+// buffered in prevLazy; here it is decoded and searched. No-op unless tailRescue
+// is set. Safe to call at every end-of-stream point — it clears the flag.
+func (s *BlockSearcher) rescueTail(pattern []byte, fn func(SearchResult) error) error {
+	if !s.tailRescue {
+		return nil
+	}
+	s.tailRescue = false
+	lb := s.prevLazy
+	if lb == nil {
+		return nil
+	}
+	blk := lb.decode()
+	if blk == nil {
+		return ErrCorrupt
+	}
+	if s.collectStats {
+		// Re-classify the block: searched, not skipped.
+		s.stats.BlocksSkipped--
+		s.stats.CompBytesSkipped -= int64(len(lb.chunkData))
+		s.stats.BlocksSearched++
+		s.stats.UncompBytesSearched += int64(len(blk))
+	}
+	s.blockMatches = 0
+	// An all-zero table is skipped only when no boundary match from the previous
+	// block is possible, so the block is self-contained and needs no prev context.
+	s.prevBlock = nil
+	s.prevLazy = nil
+	s.tailBuf = s.tailBuf[:0]
+	if err := s.dispatchMatches(blk, s.tailRescueOff, pattern, fn); err != nil {
+		return err
+	}
+	if s.collectStats && s.blockMatches == 0 {
+		s.stats.BlocksFalsePositive++
+	}
+	return nil
+}
+
 // bufferSkippedBlock reads and buffers a compressed block's data for lazy PrevBlock().
 func (s *BlockSearcher) bufferSkippedBlock(chunkType byte, chunkLen int) (decompLen int, err error) {
 	s.ensureBuf(chunkLen)
@@ -1370,33 +1443,31 @@ func canBoundaryMatch(prev, pattern []byte) bool {
 // canUse return using ONLY the config + pattern — no bitmap needed. Callers
 // use this to decide whether to spend the cost of decoding the bitmap.
 func patternCanUseConfig(cfg *SearchTableConfig, pattern []byte) bool {
-	if len(pattern) < int(cfg.matchLen) {
-		return false
-	}
 	switch cfg.tableType {
 	case searchTableTypeNoPrefix:
-		return true
+		return len(pattern) >= int(cfg.matchLen)
 	case searchTableTypeBytePrefix:
+		if len(pattern) < int(cfg.matchLen) {
+			return false
+		}
 		var pfxMask [32]byte
 		for _, p := range cfg.prefixBytes {
 			pfxMask[p>>3] |= 1 << (p & 7)
 		}
 		return patternHasPrefixContext(&pfxMask, pattern, int(cfg.matchLen))
 	case searchTableTypeMaskPrefix:
-		return patternHasPrefixContext(&cfg.prefixMask, pattern, int(cfg.matchLen))
-	case searchTableTypeLongPrefix:
-		ml := int(cfg.matchLen)
-		ex := int(cfg.extras)
-		pl := len(cfg.longPrefix)
-		if pl == 0 || len(pattern) < pl+ml+ex {
+		if len(pattern) < int(cfg.matchLen) {
 			return false
 		}
-		for i := 0; i <= len(pattern)-pl-ml-ex; i++ {
-			if bytes.Equal(pattern[i:i+pl], cfg.longPrefix) {
-				return true
-			}
-		}
-		return false
+		return patternHasPrefixContext(&cfg.prefixMask, pattern, int(cfg.matchLen))
+	case searchTableTypeLongPrefix:
+		// Usable whenever the pattern contains the prefix. Occurrences with a
+		// full matchLen(+extras) window are answered precisely by patternCanMatch;
+		// a prefix-only pattern (the pattern is shorter than the window, e.g. it
+		// IS the prefix) is answered by table emptiness. Both need the bitmap
+		// decoded, so report usable in either case — even when the pattern is
+		// shorter than matchLen.
+		return len(cfg.longPrefix) > 0 && bytes.Contains(pattern, cfg.longPrefix)
 	}
 	return false
 }
@@ -1476,9 +1547,6 @@ func patternCanMatch(cfg *SearchTableConfig, table []byte, reductions uint8, pat
 		pl := len(cfg.longPrefix)
 		ml := int(cfg.matchLen)
 		ex := int(cfg.extras)
-		if len(pattern) < ml+ex {
-			return false, true
-		}
 		checked := 0
 		firstCheckedAllPresent := false
 		for i := 0; i <= len(pattern)-pl-ml-ex; i++ {
@@ -1507,10 +1575,21 @@ func patternCanMatch(cfg *SearchTableConfig, table []byte, reductions uint8, pat
 			}
 			checked++
 		}
-		if checked == 0 {
-			return false, true
+		if checked > 0 {
+			return true, true
 		}
-		return true, true
+		// No occurrence has a full matchLen(+extras) window inside the pattern —
+		// a prefix-only query (the pattern is too short, e.g. it IS the prefix).
+		// The table indexes every position where the prefix starts in the block,
+		// so an all-zero table proves the prefix — and any pattern containing it —
+		// is absent. A non-empty table can't be narrowed further here. (A stream's
+		// final block is tabled without forward overlap, so the caller must still
+		// scan it on EOF rather than trust an all-zero table; see the tail-rescue
+		// path in the searchers.)
+		if pl > 0 && bytes.Contains(pattern, cfg.longPrefix) {
+			return true, !tableAllZero(table)
+		}
+		return false, true
 	}
 
 	return false, true

--- a/search_table.go
+++ b/search_table.go
@@ -447,6 +447,18 @@ func parseSearchTable(payload []byte, ignoreCRC bool) (cfg SearchTableConfig, re
 	return
 }
 
+// tableAllZero reports whether the bitmap has no bits set. For a prefix table
+// that means no prefix occurrence starts in the block (an empty table reduces
+// to the 32-byte minimum, so this scan is cheap).
+func tableAllZero(table []byte) bool {
+	for _, b := range table {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // readLE64Pad reads up to 8 bytes from b as a little-endian uint64, zero-padding if short.
 func readLE64Pad(b []byte) uint64 {
 	if len(b) >= 8 {

--- a/search_test.go
+++ b/search_test.go
@@ -2351,6 +2351,9 @@ func TestSearchWriteReadInterleaved(t *testing.T) {
 // FuzzSearchRoundtrip compresses with search tables and verifies decodability + search correctness.
 func FuzzSearchRoundtrip(f *testing.F) {
 	f.Add([]byte("hello world this is a test with NEEDLE inside"), []byte("NEEDLE"), 4, true)
+	// data[2] odd selects the prefix-only arm (long prefix == whole pattern);
+	// "co64" appears mid-data and at the very end (final-block tail rescue).
+	f.Add([]byte("xx\x01 a co64 box here and one final co64"), []byte("co64"), 6, true)
 	f.Fuzz(func(t *testing.T, data, pattern []byte, matchLen int, usePrefix bool) {
 		if len(data) < 32 || len(pattern) < 1 || len(pattern) > 100 {
 			return
@@ -2363,11 +2366,21 @@ func FuzzSearchRoundtrip(f *testing.F) {
 		// (multi-byte) prefix when the pattern is long enough, so the fuzzer
 		// exercises the long-prefix boundary-straddle path too.
 		useLong := false
+		prefixOnly := false
 		if usePrefix && len(pattern) > 0 {
-			if len(data) > 1 && data[1]&1 == 1 && len(pattern) >= 2+matchLen {
+			switch {
+			case len(data) > 2 && data[2]&1 == 1:
+				// Prefix-only: the long prefix IS the whole search pattern, so the
+				// pattern has no matchLen window after it. The searcher must rule
+				// out all-zero tables yet still find every occurrence — including
+				// one in the no-overlap final block (the EOF tail-rescue path).
+				cfg = cfg.WithLongPrefix(pattern)
+				useLong = true
+				prefixOnly = true
+			case len(data) > 1 && data[1]&1 == 1 && len(pattern) >= 2+matchLen:
 				cfg = cfg.WithLongPrefix(pattern[:2])
 				useLong = true
-			} else {
+			default:
 				cfg = cfg.WithBytePrefix(pattern[0])
 			}
 		}
@@ -2437,7 +2450,18 @@ func FuzzSearchRoundtrip(f *testing.F) {
 
 		// Collect all expected match offsets from the original data.
 		var expected []int64
-		if useLong {
+		if prefixOnly {
+			// pattern == long prefix: every occurrence of the pattern must be found.
+			off := 0
+			for {
+				idx := bytes.Index(data[off:], pattern)
+				if idx < 0 {
+					break
+				}
+				expected = append(expected, int64(off+idx))
+				off += idx + 1
+			}
+		} else if useLong {
 			// Long prefix: count occurrences preceded by the long prefix
 			// (conservative subset that must always be found).
 			lp := pattern[:2]

--- a/sidecar_search.go
+++ b/sidecar_search.go
@@ -85,6 +85,16 @@ type SidecarSearcher struct {
 	tailOff int64
 	bbuf    []byte
 
+	// tailRescue is set when the most recently processed block was skipped only
+	// because its (prefix) search table was all-zero. Sound for blocks with
+	// forward overlap, but a stream's final block is tabled without it (SPEC
+	// §B.4.3), so a prefix in its last bytes may be unindexed. If that block
+	// turns out to be the stream's last (end-of-stream reached with this set) it
+	// is fetched and scanned instead of skipped. Cleared as each block is processed.
+	tailRescue    bool
+	tailRescueRef remoteRef // location of the held-back block in the main stream
+	tailRescueOff int64     // stream offset where it starts
+
 	// Options.
 	bail         bool
 	ignoreCRC    bool
@@ -193,6 +203,7 @@ func (s *SidecarSearcher) Search(pattern []byte, fn func(SearchResult) error) er
 	s.prevBlock = nil
 	s.prevLazy = nil
 	s.tailBuf = s.tailBuf[:0]
+	s.tailRescue = false
 	s.winInit = false
 	s.blockStart = 0
 	s.pending = s.pending[:0]
@@ -242,7 +253,7 @@ func (s *SidecarSearcher) Search(pattern []byte, fn func(SearchResult) error) er
 		ct, cl, err := s.readChunkHeader()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return s.finalize(fn, flushBatch)
+				return s.finalize(pattern, fn, flushBatch)
 			}
 			return err
 		}
@@ -382,7 +393,8 @@ func (s *SidecarSearcher) Search(pattern []byte, fn func(SearchResult) error) er
 				if s.collectStats {
 					s.stats.BlocksTotal++
 				}
-				skip, anyUsable := s.blockDecision(tables, pattern)
+				s.tailRescue = false
+				skip, anyUsable, emptySkip := s.blockDecision(tables, pattern)
 				if s.bail && !anyUsable {
 					return ErrSearchTablesUnusable
 				}
@@ -411,6 +423,11 @@ func (s *SidecarSearcher) Search(pattern []byte, fn func(SearchResult) error) er
 					}
 					s.prevBlock = nil
 					s.tailBuf = s.tailBuf[:0]
+					// An all-zero table can't prove absence in a no-overlap final
+					// block; remember it so end-of-stream scans this block.
+					s.tailRescue = emptySkip
+					s.tailRescueRef = ref
+					s.tailRescueOff = s.blockStart
 					if s.deferred != nil {
 						if err := s.flushDeferred(nil, fn); err != nil {
 							return err
@@ -490,6 +507,10 @@ func (s *SidecarSearcher) Search(pattern []byte, fn func(SearchResult) error) er
 			if err := flushBatch(); err != nil {
 				return err
 			}
+			// Scan a tail block held back from skipping (final block of this stream).
+			if err := s.rescueTail(pattern, fn); err != nil {
+				return err
+			}
 			if s.deferred != nil {
 				if err := s.flushDeferred(nil, fn); err != nil {
 					return err
@@ -519,6 +540,11 @@ func (s *SidecarSearcher) Search(pattern []byte, fn func(SearchResult) error) er
 				if err := flushBatch(); err != nil {
 					return err
 				}
+			}
+			// Scan a tail block held back from the prior stream (defensive: a
+			// well-formed stream ends with chunkTypeEOF, which already rescues).
+			if err := s.rescueTail(pattern, fn); err != nil {
+				return err
 			}
 			if cl != magicBodyLen {
 				return ErrSidecarInvalid
@@ -555,17 +581,54 @@ func (s *SidecarSearcher) Search(pattern []byte, fn func(SearchResult) error) er
 }
 
 // finalize drains pending state at end-of-sidecar.
-func (s *SidecarSearcher) finalize(fn func(SearchResult) error, flush func() error) error {
+func (s *SidecarSearcher) finalize(pattern []byte, fn func(SearchResult) error, flush func() error) error {
 	if s.collectStats {
 		defer func() { s.stats.UncompressedSize = s.blockStart }()
 	}
 	if err := flush(); err != nil {
 		return err
 	}
+	if err := s.rescueTail(pattern, fn); err != nil {
+		return err
+	}
 	if s.deferred != nil {
 		if err := s.flushDeferred(nil, fn); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// rescueTail fetches and scans a block that was skipped only because its
+// (prefix) table was all-zero, once that block proves to be a stream's final
+// block (its table has no forward overlap, so an all-zero table cannot prove a
+// prefix-only pattern absent). No-op unless tailRescue is set; clears the flag.
+func (s *SidecarSearcher) rescueTail(pattern []byte, fn func(SearchResult) error) error {
+	if !s.tailRescue {
+		return nil
+	}
+	s.tailRescue = false
+	blk, err := readAndDecodeMainBlock(s.main, s.tailRescueRef.offset, s.tailRescueRef.uncompSize, s.maxBlock, s.ignoreCRC)
+	if err != nil {
+		return err
+	}
+	if s.collectStats {
+		// Re-classify the block: searched, not skipped.
+		s.stats.BlocksSkipped--
+		s.stats.BlocksSearched++
+		s.stats.UncompBytesSearched += int64(len(blk))
+	}
+	s.blockMatches = 0
+	// An all-zero table is skipped only when no boundary match from the previous
+	// block is possible, so the block is self-contained and needs no prev context.
+	s.prevBlock = nil
+	s.prevLazy = nil
+	s.tailBuf = s.tailBuf[:0]
+	if err := s.dispatchSidecarMatches(blk, s.tailRescueOff, pattern, fn); err != nil {
+		return err
+	}
+	if s.collectStats && s.blockMatches == 0 {
+		s.stats.BlocksFalsePositive++
 	}
 	return nil
 }
@@ -627,12 +690,12 @@ func (s *SidecarSearcher) resolveSideDeferred(nextTables []blockTableEntry, batc
 //     be decoded.
 //   - If no tables are usable (or none are present at all), the caller falls
 //     back to decode (or bails).
-func (s *SidecarSearcher) blockDecision(tables []blockTableEntry, pattern []byte) (skip, anyUsable bool) {
+func (s *SidecarSearcher) blockDecision(tables []blockTableEntry, pattern []byte) (skip, anyUsable, emptySkip bool) {
 	if len(tables) == 0 {
 		if s.collectStats {
 			s.stats.TablesMissing++
 		}
-		return false, false
+		return false, false, false
 	}
 	for i := range tables {
 		t := &tables[i]
@@ -647,7 +710,9 @@ func (s *SidecarSearcher) blockDecision(tables []blockTableEntry, pattern []byte
 		}
 		anyUsable = true
 		if !mightMatch {
-			return true, true
+			// emptySkip: an all-zero table can't prove absence in a no-overlap
+			// final block, so the caller must scan that block at end-of-stream.
+			return true, true, tableAllZero(t.table)
 		}
 	}
 	if !anyUsable {
@@ -655,7 +720,7 @@ func (s *SidecarSearcher) blockDecision(tables []blockTableEntry, pattern []byte
 			s.stats.TablesUnusable++
 		}
 	}
-	return false, anyUsable
+	return false, anyUsable, false
 }
 
 // decodeBatch issues one (or, in pathological cases, more) ReadAt(s) to fetch


### PR DESCRIPTION
When searching for the prefix only, an empty table can be used to reject blocks.

Before/after:

```
λ mz sidecar build -search.prefix=co64 DJI_20260429201005_0016_D.MP4.mz

λ mz search -v -c co64 DJI_20260429201005_0016_D.MP4.mz
DJI_20260429201005_0016_D.MP4.mz: using sidecar DJI_20260429201005_0016_D.MP4.mz.mzs
DJI_20260429201005_0016_D.MP4.mz: search info: matchLen=6 baseTableSize=23 (8388608 entries) long-prefix="co64"
6
DJI_20260429201005_0016_D.MP4.mz took 6.522s 2332.0 MB/s
Blocks total: 1814, skipped: 0 (0.0%), deferred: 0 (0.0%, 0 skipped)
Blocks searched: 1814 (100.0%), false positive: 1810 (99.8%)
Bytes skipped: 0 compressed, searched: 15208999211 uncompressed
Tables: 1814 present, 0 missing, 1814 unusable
Table bits/byte: 0.0000, log2: 8.0, avg reductions: 15.0
Table total: 39912 bytes, avg 22 bytes/table, 0.00% of 15208999211 uncompressed
Table population: avg 0.0%, min 0.0%, max 0.0%
Table types: 0 uncompressed (0x45), 1814 compressed (0x46)
Compressed tables: 1814 (100.0% of total), 39912 wire bytes, 58048 uncompressed bitmap bytes (68.76% ratio)
 Sub-blocks: 0 total (0 tabled, 0 raw, 0 RLE, 0 sparse); 0 tables emitted (share=0.00 tables/tabled-block)
 Payload bytes: tabled=0 raw=0 RLE=0 sparse=0; table-header bytes=0

λ go build&&mz search -v -c co64 DJI_20260429201005_0016_D.MP4.mz
DJI_20260429201005_0016_D.MP4.mz: using sidecar DJI_20260429201005_0016_D.MP4.mz.mzs
DJI_20260429201005_0016_D.MP4.mz: search info: matchLen=6 baseTableSize=23 (8388608 entries) long-prefix="co64"
6
DJI_20260429201005_0016_D.MP4.mz took 18ms 844944.4 MB/s
Blocks total: 1814, skipped: 1809 (99.7%), deferred: 0 (0.0%, 0 skipped)
Blocks searched: 5 (0.3%), false positive: 1 (20.0%)
Bytes skipped: 0 compressed, searched: 34007339 uncompressed
Tables: 1814 present, 0 missing, 0 unusable
Table bits/byte: 0.0000, log2: 8.0, avg reductions: 15.0
Table total: 39912 bytes, avg 22 bytes/table, 0.00% of 15208999211 uncompressed
Table population: avg 0.0%, min 0.0%, max 0.4%
Table types: 0 uncompressed (0x45), 1814 compressed (0x46)
Compressed tables: 1814 (100.0% of total), 39912 wire bytes, 58048 uncompressed bitmap bytes (68.76% ratio)
 Sub-blocks: 1814 total (0 tabled, 0 raw, 1810 RLE, 4 sparse); 0 tables emitted (share=0.00 tables/tabled-block)
 Payload bytes: tabled=0 raw=0 RLE=1810 sparse=8; table-header bytes=0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Stream Searching docs with clearer “How It Works” guidance, revised search-table setup examples, and new details on long exact matches and prefix behavior at stream ends.
  * Refined final-block/prefix-only behavior notes for end-of-stream handling.
* **Bug Fixes**
  * Improved end-of-stream accuracy by rescanning certain blocks that were previously skipped due to all-zero prefix tables.
  * Adjusted long-prefix handling so prefix-only queries don’t miss matches in the final-block tail.
* **Tests**
  * Broadened fuzz coverage and updated expected offset logic for prefix and final-block scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->