### PR TITLE
search: Fix miscounting

### DIFF
--- a/cmd/mz/search.go
+++ b/cmd/mz/search.go
@@ -178,7 +178,7 @@ func searchFile(file string, pattern []byte, opts searchOpts) (found bool, stats
 
 	matchCount := 0
 	lineOffset := int64(1)
-	lastLineEnd := int64(-1)
+	lastLineStart := int64(-1)
 
 	err = searcher.Search(pattern, func(r minlz.SearchResult) error {
 		found = true
@@ -192,17 +192,21 @@ func searchFile(file string, pattern []byte, opts searchOpts) (found bool, stats
 		}
 
 		if opts.lines {
-			// Skip matches within an already-emitted line.
-			if r.StreamOffset < lastLineEnd {
+			// Count each matching line once. Dedup by the line's start offset —
+			// found by scanning back, into the previous block only when the line
+			// begins there — rather than by its end. This keeps a line that
+			// straddles a block boundary and matches in both halves counted once,
+			// matching grep/rg.
+			ls := lineStartOffset(r)
+			if ls == lastLineStart {
 				return nil
 			}
+			lastLineStart = ls
 			if opts.count {
-				lastLineEnd = r.StreamOffset + int64(lineEndOffset(r, pattern))
 				matchCount++
 				return nil
 			}
-			line, endOff := extractLine(r, pattern)
-			lastLineEnd = r.StreamOffset + int64(endOff)
+			line := extractLine(r, pattern)
 			matchCount++
 			if opts.lineNums {
 				fmt.Printf("%s%d:%d:%s\n", prefix, lineOffset, r.StreamOffset, line)
@@ -237,38 +241,91 @@ func searchFile(file string, pattern []byte, opts searchOpts) (found bool, stats
 	return found, stats, nil
 }
 
-// lineEndOffset returns the distance from the match start to the end of its line.
-// Avoids allocating by searching Blocks[1] directly.
-func lineEndOffset(r minlz.SearchResult, pattern []byte) int {
-	posInBlk := r.Offset - r.PrevBlockLen
-	after := max(posInBlk+len(pattern), 0)
-	blk := r.Blocks[1]
-	if after < len(blk) {
-		if idx := bytes.IndexByte(blk[after:], '\n'); idx >= 0 {
-			return after - posInBlk + idx
+// lineStartOffset returns the absolute stream offset of the start of the line
+// containing the match. It scans the current block back to the preceding
+// newline and only consults the previous block (via PrevBlock, which may lazily
+// decode) when the line begins before the current block — so counting a line
+// that lies within one block never touches the previous block.
+func lineStartOffset(r minlz.SearchResult) int64 {
+	pl := r.PrevBlockLen
+	if posInCur := r.Offset - pl; posInCur > 0 {
+		if nl := bytes.LastIndexByte(r.Blocks[1][:posInCur], '\n'); nl >= 0 {
+			return r.BlockStart + int64(pl+nl+1)
 		}
 	}
-	return len(blk) - posInBlk
+	prev := r.PrevBlock()
+	if end := min(r.Offset, len(prev)); end > 0 {
+		if nl := bytes.LastIndexByte(prev[:end], '\n'); nl >= 0 {
+			return r.BlockStart + int64(nl+1)
+		}
+	}
+	return r.BlockStart
 }
 
-// extractLine extracts the full line containing the match.
-// Returns the line and the distance from the match start to the line end.
-func extractLine(r minlz.SearchResult, pattern []byte) (string, int) {
+// extractLine returns the line containing the match. It copies only the line's
+// bytes (never whole blocks): a sub-slice of one block when the line fits in it,
+// or the previous block's tail joined with the current block's head when the
+// line straddles the boundary. The line is truncated at the current block's end
+// if it continues into the next block (no forward block is fetched).
+func extractLine(r minlz.SearchResult, pattern []byte) string {
 	prev := r.PrevBlock()
-	data := append(prev, r.Blocks[1]...)
-	matchPos := r.Offset
+	cur := r.Blocks[1]
+	pl := len(prev)
 
-	lineStart := bytes.LastIndexByte(data[:matchPos], '\n')
-	if lineStart < 0 {
-		lineStart = 0
-	} else {
-		lineStart++
+	start := 0
+	if nl := lastNewline(prev, cur, r.Offset); nl >= 0 {
+		start = nl + 1
 	}
-	lineEnd := bytes.IndexByte(data[matchPos+len(pattern):], '\n')
-	if lineEnd < 0 {
-		lineEnd = len(data)
-	} else {
-		lineEnd += matchPos + len(pattern)
+	end := pl + len(cur)
+	if nl := firstNewline(prev, cur, r.Offset+len(pattern)); nl >= 0 {
+		end = nl
 	}
-	return string(data[lineStart:lineEnd]), lineEnd - matchPos
+
+	switch {
+	case end <= pl:
+		return string(prev[start:end])
+	case start >= pl:
+		return string(cur[start-pl : end-pl])
+	default:
+		buf := make([]byte, 0, end-start)
+		buf = append(buf, prev[start:]...)
+		buf = append(buf, cur[:end-pl]...)
+		return string(buf)
+	}
+}
+
+// lastNewline returns the index of the last '\n' strictly before upto in the
+// logical buffer prev||cur, or -1. firstNewline returns the index of the first
+// '\n' at or after from. Both index the concatenation without materializing it.
+func lastNewline(prev, cur []byte, upto int) int {
+	pl := len(prev)
+	if upto > pl {
+		if i := bytes.LastIndexByte(cur[:upto-pl], '\n'); i >= 0 {
+			return pl + i
+		}
+		upto = pl
+	}
+	if upto > 0 {
+		return bytes.LastIndexByte(prev[:min(upto, pl)], '\n')
+	}
+	return -1
+}
+
+func firstNewline(prev, cur []byte, from int) int {
+	pl := len(prev)
+	if from < 0 {
+		from = 0
+	}
+	if from < pl {
+		if i := bytes.IndexByte(prev[from:], '\n'); i >= 0 {
+			return from + i
+		}
+		from = pl
+	}
+	if from-pl < len(cur) {
+		if i := bytes.IndexByte(cur[from-pl:], '\n'); i >= 0 {
+			return from + i
+		}
+	}
+	return -1
 }

--- a/cmd/mz/search.go
+++ b/cmd/mz/search.go
@@ -193,6 +193,15 @@ func searchFile(file string, pattern []byte, opts searchOpts) (found bool, stats
 	matchCount := 0
 	lineOffset := int64(1)
 	lastLineStart := int64(-1)
+	// contigEnd is the stream offset just past the last block a match was
+	// resolved in. A still-open line (no newline in the current or previous
+	// block) reuses the open key only when the match is at most one block past
+	// contigEnd — that single intervening block is the previous block, which
+	// lineStartOffset actually scans (lazily decoding it even when skipped), so a
+	// separating newline there is caught. A wider gap of 2+ skipped blocks is
+	// never decoded; since blocks are large, a line spanning them is unlikely, so
+	// we assume the gap held a newline and start a new line.
+	contigEnd := int64(-1)
 
 	err = searcher.Search(pattern, func(r minlz.SearchResult) error {
 		found = true
@@ -208,17 +217,15 @@ func searchFile(file string, pattern []byte, opts searchOpts) (found bool, stats
 		if opts.lines {
 			// Count each matching line once, keyed by the line's start offset.
 			// A match with no preceding newline in the current or previous block
-			// belongs to a line that began earlier, so reuse the open line's key:
-			// a newline-sparse line (e.g. minified JSON) is counted once, not once
-			// per block, even when match-free blocks between matches are skipped
-			// without being decoded. This assumes skipped blocks hold no newline;
-			// a newline hidden in a skipped block that splits two long matching
-			// lines would undercount, which the block search deliberately can't
-			// see without decoding what it skipped.
+			// belongs to a line that began earlier; reuse the open key only when
+			// the run is contiguous (see contigEnd) so a newline-sparse line
+			// spanning a block plus one skipped block is counted once. Across a
+			// wider gap we assume a newline was skipped and count a new line.
 			ls, found := lineStartOffset(r)
-			if !found && lastLineStart >= 0 {
+			if !found && lastLineStart >= 0 && r.BlockStart <= contigEnd {
 				ls = lastLineStart
 			}
+			contigEnd = r.BlockStart + int64(r.PrevBlockLen) + int64(len(r.Blocks[1]))
 			if ls == lastLineStart {
 				return nil
 			}

--- a/cmd/mz/search.go
+++ b/cmd/mz/search.go
@@ -193,11 +193,6 @@ func searchFile(file string, pattern []byte, opts searchOpts) (found bool, stats
 	matchCount := 0
 	lineOffset := int64(1)
 	lastLineStart := int64(-1)
-	// contigEnd is the stream offset just past the last block a match was
-	// resolved in — used to detect that a still-open line (one with no newline
-	// in the current or previous block) continues contiguously from an earlier
-	// block, so it keeps a single dedup key across all the blocks it spans.
-	contigEnd := int64(-1)
 
 	err = searcher.Search(pattern, func(r minlz.SearchResult) error {
 		found = true
@@ -213,16 +208,17 @@ func searchFile(file string, pattern []byte, opts searchOpts) (found bool, stats
 		if opts.lines {
 			// Count each matching line once, keyed by the line's start offset.
 			// A match with no preceding newline in the current or previous block
-			// belongs to a line that began earlier; if that block is contiguous
-			// with the run we've scanned, reuse the open line's key so a line
-			// spanning more than two blocks (e.g. newline-sparse data) is counted
-			// once, not once per block. Two-block straddles resolve via the
-			// previous block, matching grep/rg.
+			// belongs to a line that began earlier, so reuse the open line's key:
+			// a newline-sparse line (e.g. minified JSON) is counted once, not once
+			// per block, even when match-free blocks between matches are skipped
+			// without being decoded. This assumes skipped blocks hold no newline;
+			// a newline hidden in a skipped block that splits two long matching
+			// lines would undercount, which the block search deliberately can't
+			// see without decoding what it skipped.
 			ls, found := lineStartOffset(r)
-			if !found && lastLineStart >= 0 && r.BlockStart <= contigEnd {
+			if !found && lastLineStart >= 0 {
 				ls = lastLineStart
 			}
-			contigEnd = r.BlockStart + int64(r.PrevBlockLen) + int64(len(r.Blocks[1]))
 			if ls == lastLineStart {
 				return nil
 			}

--- a/cmd/mz/search.go
+++ b/cmd/mz/search.go
@@ -1,3 +1,17 @@
+// Copyright 2026 MinIO Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -179,6 +193,11 @@ func searchFile(file string, pattern []byte, opts searchOpts) (found bool, stats
 	matchCount := 0
 	lineOffset := int64(1)
 	lastLineStart := int64(-1)
+	// contigEnd is the stream offset just past the last block a match was
+	// resolved in — used to detect that a still-open line (one with no newline
+	// in the current or previous block) continues contiguously from an earlier
+	// block, so it keeps a single dedup key across all the blocks it spans.
+	contigEnd := int64(-1)
 
 	err = searcher.Search(pattern, func(r minlz.SearchResult) error {
 		found = true
@@ -192,12 +211,18 @@ func searchFile(file string, pattern []byte, opts searchOpts) (found bool, stats
 		}
 
 		if opts.lines {
-			// Count each matching line once. Dedup by the line's start offset —
-			// found by scanning back, into the previous block only when the line
-			// begins there — rather than by its end. This keeps a line that
-			// straddles a block boundary and matches in both halves counted once,
-			// matching grep/rg.
-			ls := lineStartOffset(r)
+			// Count each matching line once, keyed by the line's start offset.
+			// A match with no preceding newline in the current or previous block
+			// belongs to a line that began earlier; if that block is contiguous
+			// with the run we've scanned, reuse the open line's key so a line
+			// spanning more than two blocks (e.g. newline-sparse data) is counted
+			// once, not once per block. Two-block straddles resolve via the
+			// previous block, matching grep/rg.
+			ls, found := lineStartOffset(r)
+			if !found && lastLineStart >= 0 && r.BlockStart <= contigEnd {
+				ls = lastLineStart
+			}
+			contigEnd = r.BlockStart + int64(r.PrevBlockLen) + int64(len(r.Blocks[1]))
 			if ls == lastLineStart {
 				return nil
 			}
@@ -242,24 +267,27 @@ func searchFile(file string, pattern []byte, opts searchOpts) (found bool, stats
 }
 
 // lineStartOffset returns the absolute stream offset of the start of the line
-// containing the match. It scans the current block back to the preceding
-// newline and only consults the previous block (via PrevBlock, which may lazily
-// decode) when the line begins before the current block — so counting a line
-// that lies within one block never touches the previous block.
-func lineStartOffset(r minlz.SearchResult) int64 {
+// containing the match, and whether a preceding newline was actually found. It
+// scans the current block back to the preceding newline and only consults the
+// previous block (via PrevBlock, which may lazily decode) when the line begins
+// before the current block — so counting a line that lies within one block
+// never touches the previous block. When no newline is found in either block
+// (the line began before them) it returns (r.BlockStart, false); the caller
+// recovers the true start from carried continued-line state.
+func lineStartOffset(r minlz.SearchResult) (int64, bool) {
 	pl := r.PrevBlockLen
 	if posInCur := r.Offset - pl; posInCur > 0 {
 		if nl := bytes.LastIndexByte(r.Blocks[1][:posInCur], '\n'); nl >= 0 {
-			return r.BlockStart + int64(pl+nl+1)
+			return r.BlockStart + int64(pl+nl+1), true
 		}
 	}
 	prev := r.PrevBlock()
 	if end := min(r.Offset, len(prev)); end > 0 {
 		if nl := bytes.LastIndexByte(prev[:end], '\n'); nl >= 0 {
-			return r.BlockStart + int64(nl+1)
+			return r.BlockStart + int64(nl+1), true
 		}
 	}
-	return r.BlockStart
+	return r.BlockStart, false
 }
 
 // extractLine returns the line containing the match. It copies only the line's
@@ -268,10 +296,32 @@ func lineStartOffset(r minlz.SearchResult) int64 {
 // line straddles the boundary. The line is truncated at the current block's end
 // if it continues into the next block (no forward block is fetched).
 func extractLine(r minlz.SearchResult, pattern []byte) string {
-	prev := r.PrevBlock()
 	cur := r.Blocks[1]
-	pl := len(prev)
+	// Match start relative to the current block (PrevBlockLen is known without
+	// decoding prev). <0 means the match itself begins in the previous block.
+	mInCur := r.Offset - r.PrevBlockLen
 
+	// Fast path: the match is in the current block. The line end is found by
+	// scanning forward within cur (a line continuing past the block is truncated
+	// here — no next block is fetched), so it never needs prev. If the line start
+	// is also within cur, the whole line lives here and we return it without
+	// calling PrevBlock (which would lazily decode a skipped previous block).
+	if mInCur >= 0 {
+		end := len(cur)
+		if e := mInCur + len(pattern); e <= len(cur) {
+			if nl := bytes.IndexByte(cur[e:], '\n'); nl >= 0 {
+				end = e + nl
+			}
+		}
+		if nl := bytes.LastIndexByte(cur[:mInCur], '\n'); nl >= 0 {
+			return string(cur[nl+1 : end])
+		}
+	}
+
+	// The line's start (or the match itself) crosses into the previous block;
+	// fetch it now and use the logical prev||cur boundary logic.
+	prev := r.PrevBlock()
+	pl := len(prev)
 	start := 0
 	if nl := lastNewline(prev, cur, r.Offset); nl >= 0 {
 		start = nl + 1

--- a/cmd/mz/search_test.go
+++ b/cmd/mz/search_test.go
@@ -103,26 +103,27 @@ func captureCount(t *testing.T, path, pattern string) int {
 	return n
 }
 
-// TestSearchCountLongLineManyBlocks guards against counting a single
-// newline-free line (e.g. minified JSON) once per block instead of once. The
-// line spans many blocks with matches throughout; grep counts one matching
-// line, so mz must too. "gapped" leaves the needle out of odd blocks so they
-// are skipped at search time, exercising continuation across a skipped block.
+// TestSearchCountLongLineManyBlocks pins how a single newline-free line (e.g.
+// minified JSON) is counted when its matches are spread across blocks. A
+// skipped block between two matches is the previous block of the later match,
+// so it is scanned for a separating newline: "contiguous" and "gapped" (one
+// skipped block between matches) resolve to a single line. A wider gap of 2+
+// skipped blocks is never decoded; since blocks are large a line spanning them
+// is unlikely, so "widegap" assumes a newline was skipped and counts each
+// matching block as its own line (4 matches -> 4).
 func TestSearchCountLongLineManyBlocks(t *testing.T) {
 	const block = 4096
 	needle := []byte("NEEDLE")
-	// hasNeedle selects which blocks carry the needle. Each case is a single
-	// newline-free logical line spanning all blocks, so the count must be 1
-	// however many match-free blocks fall between matches. "widegap" leaves two
-	// adjacent match-free blocks between matches, so the continuation state must
-	// bridge more than one skipped block, not just alternating ones.
+	// hasNeedle selects which blocks carry the needle; want is the expected line
+	// count under the single-block-gap continuation rule described above.
 	cases := []struct {
 		name      string
 		hasNeedle func(i int) bool
+		want      int
 	}{
-		{"contiguous", func(i int) bool { return true }},
-		{"gapped", func(i int) bool { return i%2 == 0 }},
-		{"widegap", func(i int) bool { return i%3 == 0 }},
+		{"contiguous", func(i int) bool { return true }, 1},
+		{"gapped", func(i int) bool { return i%2 == 0 }, 1},
+		{"widegap", func(i int) bool { return i%3 == 0 }, 4},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -147,8 +148,8 @@ func TestSearchCountLongLineManyBlocks(t *testing.T) {
 			if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
 				t.Fatal(err)
 			}
-			if got := captureCount(t, path, string(needle)); got != 1 {
-				t.Fatalf("count=%d, want 1 (a newline-free line must count once, not once per block)", got)
+			if got := captureCount(t, path, string(needle)); got != tc.want {
+				t.Fatalf("count=%d, want %d", got, tc.want)
 			}
 		})
 	}

--- a/cmd/mz/search_test.go
+++ b/cmd/mz/search_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 MinIO Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/minio/minlz"
+)
+
+// TestSearchCountLineStraddle guards against double-counting a matching line
+// that straddles a block boundary and matches in both halves. `mz search -c`
+// counts matching lines (grep/rg semantics), so such a line must count once.
+func TestSearchCountLineStraddle(t *testing.T) {
+	const block = 4096
+	filler := []byte("z,Queens,zz\n") // 12 bytes, no "Manhattan"
+	row := []byte("R,Manhattan,PPPPPPPPPPPPPPPPPPPP,Manhattan,E\n")
+	m1 := bytes.Index(row, []byte("Manhattan"))
+	m2 := bytes.Index(row[m1+1:], []byte("Manhattan")) + m1 + 1
+
+	// Pick filler count so the row's first "Manhattan" sits in block 0 and the
+	// second in block 1.
+	k := 0
+	for {
+		rs := k * len(filler)
+		if rs+m1+len("Manhattan") <= block && rs+m2 >= block {
+			break
+		}
+		if k++; k > block {
+			t.Fatal("could not position a straddling row")
+		}
+	}
+
+	var data []byte
+	data = append(data, bytes.Repeat(filler, k)...)
+	data = append(data, row...) // straddling line, 2 matches
+	data = append(data, bytes.Repeat(filler, 10)...)
+	data = append(data, []byte("SECOND,Manhattan,x\n")...) // one more distinct match
+	data = append(data, bytes.Repeat(filler, 10)...)
+
+	var buf bytes.Buffer
+	cfg := minlz.NewSearchTableConfig().WithMatchLen(6)
+	w := minlz.NewWriter(&buf, minlz.WriterSearchTable(cfg), minlz.WriterBlockSize(block), minlz.WriterConcurrency(1))
+	if _, err := w.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if want := bytes.Count(data, []byte("Manhattan")); want != 3 {
+		t.Fatalf("test setup: expected 3 raw matches (2 in the straddling row + 1), got %d", want)
+	}
+
+	path := filepath.Join(t.TempDir(), "straddle.mz")
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := captureCount(t, path, "Manhattan")
+	if got != 2 {
+		t.Fatalf("mz search -c counted %d matching lines, want 2 (the straddling line must count once)", got)
+	}
+}
+
+// captureCount runs searchFile in count/line mode and returns the printed count.
+func captureCount(t *testing.T, path, pattern string) int {
+	t.Helper()
+	old := os.Stdout
+	rp, wp, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = wp
+	_, _, serr := searchFile(path, []byte(pattern), searchOpts{count: true, lines: true})
+	wp.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(rp)
+	if serr != nil {
+		t.Fatalf("searchFile: %v", serr)
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		t.Fatalf("parsing count %q: %v", out, err)
+	}
+	return n
+}
+
+// TestSearchCountLongLineManyBlocks guards against counting a single
+// newline-free line (e.g. minified JSON) once per block instead of once. The
+// line spans many blocks with matches throughout; grep counts one matching
+// line, so mz must too. "gapped" leaves the needle out of odd blocks so they
+// are skipped at search time, exercising continuation across a skipped block.
+func TestSearchCountLongLineManyBlocks(t *testing.T) {
+	const block = 4096
+	needle := []byte("NEEDLE")
+	for _, gapped := range []bool{false, true} {
+		name := "contiguous"
+		if gapped {
+			name = "gapped"
+		}
+		t.Run(name, func(t *testing.T) {
+			var data []byte
+			for i := range 10 {
+				chunk := bytes.Repeat([]byte("x"), block) // no newlines: one logical line
+				if !gapped || i%2 == 0 {
+					copy(chunk[100:], needle)
+				}
+				data = append(data, chunk...)
+			}
+			var buf bytes.Buffer
+			cfg := minlz.NewSearchTableConfig().WithMatchLen(6)
+			w := minlz.NewWriter(&buf, minlz.WriterSearchTable(cfg), minlz.WriterBlockSize(block), minlz.WriterConcurrency(1))
+			if _, err := w.Write(data); err != nil {
+				t.Fatal(err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(t.TempDir(), "long.mz")
+			if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if got := captureCount(t, path, string(needle)); got != 1 {
+				t.Fatalf("count=%d, want 1 (a newline-free line must count once, not once per block)", got)
+			}
+		})
+	}
+}

--- a/cmd/mz/search_test.go
+++ b/cmd/mz/search_test.go
@@ -111,16 +111,25 @@ func captureCount(t *testing.T, path, pattern string) int {
 func TestSearchCountLongLineManyBlocks(t *testing.T) {
 	const block = 4096
 	needle := []byte("NEEDLE")
-	for _, gapped := range []bool{false, true} {
-		name := "contiguous"
-		if gapped {
-			name = "gapped"
-		}
-		t.Run(name, func(t *testing.T) {
+	// hasNeedle selects which blocks carry the needle. Each case is a single
+	// newline-free logical line spanning all blocks, so the count must be 1
+	// however many match-free blocks fall between matches. "widegap" leaves two
+	// adjacent match-free blocks between matches, so the continuation state must
+	// bridge more than one skipped block, not just alternating ones.
+	cases := []struct {
+		name      string
+		hasNeedle func(i int) bool
+	}{
+		{"contiguous", func(i int) bool { return true }},
+		{"gapped", func(i int) bool { return i%2 == 0 }},
+		{"widegap", func(i int) bool { return i%3 == 0 }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			var data []byte
 			for i := range 10 {
 				chunk := bytes.Repeat([]byte("x"), block) // no newlines: one logical line
-				if !gapped || i%2 == 0 {
+				if tc.hasNeedle(i) {
 					copy(chunk[100:], needle)
 				}
 				data = append(data, chunk...)


### PR DESCRIPTION
`cmd/mz/search.go` deduped by line end via lineEndOffset, which scans only the current block forward for the terminating \n. When the line ends in the next block, lastLineEnd was set to the block boundary, so the second match (next block, same line) slipped past the dedup. The searcher itself reports every match at exact offsets — only the CLI's line accounting was wrong.

Fix

 - Dedup by the line's start offset (lineStartOffset): scan backward within the current block, consulting PrevBlock() only when the line begins before it — so a straddling line resolves to the same start offset from both matches and counts once. The hot path allocates nothing and never triggers a lazy decode.
  - Rewrote extractLine while I was there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `-l/--lines` so matches on the same logical line are no longer duplicated.
  * Refined line counting and line text extraction for matches that span indexed block boundaries, keeping `--count` and line output consistent.
* **Tests**
  * Added tests covering `mz search -c -l` behavior for matches that straddle block boundaries and for long lines across multiple blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->